### PR TITLE
feat: use iam.cloud.ibm.com in IAM url; allow IAM client_id/secret to…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ python3/
 
 .sfdx/tools/apex.db
 .pytest_cache/
+/.project
+/.pydevproject
+/.settings/

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -101,14 +101,14 @@ def test_fail_http_config():
 
 @responses.activate
 def test_iam():
-    iam_url = "https://iam.bluemix.net/identity/token"
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
     service = AnyServiceV1('2017-07-07', iam_apikey="iam_apikey")
     assert service.token_manager is not None
 
-    service.set_iam_url('https://iam-test.bluemix.net/identity/token')
-    assert service.token_manager.iam_url == 'https://iam-test.bluemix.net/identity/token'
+    service.set_iam_url('https://iam-test.cloud.ibm.com/identity/token')
+    assert service.token_manager.iam_url == 'https://iam-test.cloud.ibm.com/identity/token'
 
-    iam_url = "https://iam.bluemix.net/identity/token"
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
     service = AnyServiceV1('2017-07-07', username='xxx', password='yyy')
     assert service.token_manager is None
     service.set_iam_apikey('yyy')
@@ -149,14 +149,14 @@ def test_when_apikey_is_username():
     assert service1.iam_apikey == 'xxxxx'
     assert service1.username is None
     assert service1.password is None
-    assert service1.token_manager.iam_url == 'https://iam.bluemix.net/identity/token'
+    assert service1.token_manager.iam_url == 'https://iam.cloud.ibm.com/identity/token'
 
-    service2 = AnyServiceV1('2017-07-07', username='apikey', password='xxxxx', iam_url='https://iam.stage1.bluemix.net/identity/token')
+    service2 = AnyServiceV1('2017-07-07', username='apikey', password='xxxxx', iam_url='https://iam.stage1.cloud.ibm.com/identity/token')
     assert service2.token_manager is not None
     assert service2.iam_apikey == 'xxxxx'
     assert service2.username is None
     assert service2.password is None
-    assert service2.token_manager.iam_url == 'https://iam.stage1.bluemix.net/identity/token'
+    assert service2.token_manager.iam_url == 'https://iam.stage1.cloud.ibm.com/identity/token'
 
 def test_for_icp():
     service1 = AnyServiceV1('2017-07-07', username='apikey', password='icp-xxxx', url='service_url')

--- a/test/test_iam_token_manager.py
+++ b/test/test_iam_token_manager.py
@@ -109,3 +109,153 @@ def test_get_token():
     }
     token = token_manager.get_token()
     assert token == 'dummy'
+
+@responses.activate
+def test_request_token_auth_default():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    default_auth_header = 'Basic Yng6Yng='
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = IAMTokenManager("iam_apikey", "iam_access_token")
+    token_manager._request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].request.headers['Authorization'] == default_auth_header
+    assert responses.calls[0].response.text == response
+
+@responses.activate
+def test_request_token_auth_in_ctor():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    default_auth_header = 'Basic Yng6Yng='
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = IAMTokenManager("iam_apikey", "iam_access_token", iam_url, 'foo', 'bar')
+    token_manager._request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].request.headers['Authorization'] != default_auth_header
+    assert responses.calls[0].response.text == response
+
+@responses.activate
+def test_request_token_auth_in_ctor_client_id_only():
+    iam_url = "https://iam.bluemix.net/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    default_auth_header = 'Basic Yng6Yng='
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = IAMTokenManager("iam_apikey", "iam_access_token", iam_url, 'foo')
+    token_manager._request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].request.headers['Authorization'] == default_auth_header
+    assert responses.calls[0].response.text == response
+
+@responses.activate
+def test_request_token_auth_in_ctor_secret_only():
+    iam_url = "https://iam.bluemix.net/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    default_auth_header = 'Basic Yng6Yng='
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = IAMTokenManager("iam_apikey", "iam_access_token", iam_url, None, 'bar')
+    token_manager._request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].request.headers['Authorization'] == default_auth_header
+    assert responses.calls[0].response.text == response
+
+@responses.activate
+def test_request_token_auth_in_setter():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    default_auth_header = 'Basic Yng6Yng='
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = IAMTokenManager("iam_apikey")
+    token_manager.set_iam_authorization_info('foo', 'bar')
+    token_manager._request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].request.headers['Authorization'] != default_auth_header
+    assert responses.calls[0].response.text == response
+
+@responses.activate
+def test_request_token_auth_in_setter_client_id_only():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    default_auth_header = 'Basic Yng6Yng='
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = IAMTokenManager("iam_apikey")
+    token_manager.set_iam_authorization_info('foo', None)
+    token_manager._request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].request.headers['Authorization'] == default_auth_header
+    assert responses.calls[0].response.text == response
+
+@responses.activate
+def test_request_token_auth_in_setter_secret_only():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = """{
+        "access_token": "oAeisG8yqPY7sFR_x66Z15",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": 1524167011,
+        "refresh_token": "jy4gl91BQ"
+    }"""
+    default_auth_header = 'Basic Yng6Yng='
+    responses.add(responses.POST, url=iam_url, body=response, status=200)
+
+    token_manager = IAMTokenManager("iam_apikey")
+    token_manager.set_iam_authorization_info(None, 'bar')
+    token_manager._request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == iam_url
+    assert responses.calls[0].request.headers['Authorization'] == default_auth_header
+    assert responses.calls[0].response.text == response


### PR DESCRIPTION
… be configured

Fixes: https://github.ibm.com/arf/planning-sdk-squad/issues/851
