### PR TITLE
feat(IAM): allow IAM client id/secret to be set via BaseService ctor

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -56,7 +56,7 @@ class BaseService(object):
 
     def __init__(self, vcap_services_name, url, username=None, password=None,
                  use_vcap_services=True, api_key=None,
-                 iam_apikey=None, iam_access_token=None, iam_url=None,
+                 iam_apikey=None, iam_access_token=None, iam_url=None, iam_client_id=None, iam_client_secret=None,
                  display_name=None):
         """
         It loads credentials with the following preference:
@@ -74,6 +74,8 @@ class BaseService(object):
         self.iam_apikey = None
         self.iam_access_token = None
         self.iam_url = None
+        self.iam_client_id = None
+        self.iam_client_secret = None
         self.token_manager = None
         self.verify = None # Indicates whether to ignore verifying the SSL certification
 
@@ -88,17 +90,17 @@ class BaseService(object):
             if api_key.startswith(self.ICP_PREFIX):
                 self.set_username_and_password(self.APIKEY, api_key)
             else:
-                self.set_token_manager(api_key, iam_access_token, iam_url)
+                self.set_token_manager(api_key, iam_access_token, iam_url, iam_client_id, iam_client_secret)
         elif username is not None and password is not None:
             if username is self.APIKEY and not password.startswith(self.ICP_PREFIX):
-                self.set_token_manager(password, iam_access_token, iam_url)
+                self.set_token_manager(password, iam_access_token, iam_url, iam_client_id, iam_client_secret)
             else:
                 self.set_username_and_password(username, password)
         elif iam_access_token is not None or iam_apikey is not None:
             if iam_apikey and iam_apikey.startswith(self.ICP_PREFIX):
                 self.set_username_and_password(self.APIKEY, iam_apikey)
             else:
-                self.set_token_manager(iam_apikey, iam_access_token, iam_url)
+                self.set_token_manager(iam_apikey, iam_access_token, iam_url, iam_client_id, iam_client_secret)
 
         # 2. Credentials from credential file
         if display_name and not self.username and not self.token_manager:
@@ -196,15 +198,18 @@ class BaseService(object):
         self.password = password
         self.jar = CookieJar()
 
-    def set_token_manager(self, iam_apikey=None, iam_access_token=None, iam_url=None):
+    def set_token_manager(self, iam_apikey=None, iam_access_token=None, iam_url=None, 
+                          iam_client_id=None, iam_client_secret=None):
         if has_bad_first_or_last_char(iam_apikey):
             raise ValueError('The credentials shouldn\'t start or end with curly brackets or quotes. '
                              'Be sure to remove any {} and \" characters surrounding your credentials')
 
-        self.token_manager = IAMTokenManager(iam_apikey, iam_access_token, iam_url)
+        self.token_manager = IAMTokenManager(iam_apikey, iam_access_token, iam_url, iam_client_id, iam_client_secret)
         self.iam_apikey = iam_apikey
         self.iam_access_token = iam_access_token
         self.iam_url = iam_url
+        self.iam_client_id = iam_client_id
+        self.iam_client_secret = iam_client_secret
         self.jar = CookieJar()
 
     def set_iam_access_token(self, iam_access_token):

--- a/ibm_cloud_sdk_core/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/iam_token_manager.py
@@ -25,12 +25,13 @@ class IAMTokenManager(object):
     REQUEST_TOKEN_RESPONSE_TYPE = 'cloud_iam'
     REFRESH_TOKEN_GRANT_TYPE = 'refresh_token'
 
-    def __init__(self, iam_apikey=None, iam_access_token=None, iam_url=None, iam_client_id=None, iam_secret=None):
+    def __init__(self, iam_apikey=None, iam_access_token=None, iam_url=None, 
+                 iam_client_id=None, iam_client_secret=None):
         self.iam_apikey = iam_apikey
         self.user_access_token = iam_access_token
         self.iam_url = iam_url if iam_url else self.DEFAULT_IAM_URL
         self.iam_client_id = iam_client_id
-        self.iam_secret = iam_secret
+        self.iam_client_secret = iam_client_secret
         self.token_info = {
             'access_token': None,
             'refresh_token': None,
@@ -41,8 +42,8 @@ class IAMTokenManager(object):
 
     def request(self, method, url, headers=None, params=None, data=None, **kwargs):
         auth_tuple = ('bx', 'bx')
-        if self.iam_client_id and self.iam_secret:
-            auth_tuple = (self.iam_client_id, self.iam_secret)
+        if self.iam_client_id and self.iam_client_secret:
+            auth_tuple = (self.iam_client_id, self.iam_client_secret)
         response = requests.request(method=method, url=url,
                                     headers=headers, params=params,
                                     data=data, auth=auth_tuple, **kwargs)
@@ -133,7 +134,7 @@ class IAMTokenManager(object):
         """
         self.iam_url = iam_url
 
-    def set_iam_authorization_info(self, iam_client_id, iam_secret):
+    def set_iam_authorization_info(self, iam_client_id, iam_client_secret):
         """
         Set the IAM authorization information.
         This consists of the client_id and secret.
@@ -143,7 +144,7 @@ class IAMTokenManager(object):
         is used.
         """
         self.iam_client_id = iam_client_id
-        self.iam_secret = iam_secret
+        self.iam_client_secret = iam_client_secret
 
     def _is_token_expired(self):
         """


### PR DESCRIPTION
This PR is a follow-up to my previous IAM-related PR.
This PR contains additional changes to allow the SDK user to set the IAM client_id and client_secret values when instantiating a generated service class.   In this PR I've added the parameters to the BaseService ctor, which will be called by a generated service ctor.   Note that there will be a companion PR in the python generator to allow the new parameters to be set when instantiating the generated service class as well.