### PR TITLE
vcap and json loads changes

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -44,7 +44,7 @@ class BaseService(object):
         """
         :attr str url: The url for service api calls
         :attr Authenticator authenticator: The authenticator for authentication
-        :attr bool disable_ssl_verification: enables/ disabled ssl verification
+        :attr bool disable_ssl_verification: enables/ disables ssl verification
         :attr str display_name the name used for mapping services in environment file
         """
         self.url = url
@@ -179,9 +179,13 @@ class BaseService(object):
         params = cleanup_values(params)
         request['params'] = params
 
-        data = remove_null_values(data)
         if sys.version_info >= (3, 0) and isinstance(data, str):
             data = data.encode('utf-8')
+
+        if data and isinstance(data, dict):
+            data = remove_null_values(data)
+            headers.update({'content-type': 'application/json'})
+            data = json_import.dumps(data)
         request['data'] = data
 
         if self.authenticator:

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -414,3 +414,9 @@ def test_files():
     form_data['file1'] = (None, file, 'application/octet-stream')
     form_data['string1'] = (None, 'hello', 'text.plain')
     service.prepare_request('GET', url='', headers={'X-opt-out': True}, files=form_data)
+
+
+def test_json():
+    service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
+    req = service.prepare_request('POST', url='', headers={'X-opt-out': True}, data={'hello': 'world'})
+    assert req.get('data') == "{\"hello\": \"world\"}"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -77,3 +77,12 @@ def test_vcap_credentials():
     assert authenticator is not None
     assert authenticator.token_manager.apikey == 'bogus apikey'
     del os.environ['VCAP_SERVICES']
+
+    vcap_services = '{"test":[{"credentials":{ \
+        "url":"https://gateway.watsonplatform.net/compare-comply/api",\
+        "iam_apikey":"bogus apikey"}}]}'
+
+    os.environ['VCAP_SERVICES'] = vcap_services
+    authenticator = get_authenticator_from_environment('test')
+    assert authenticator is None
+    del os.environ['VCAP_SERVICES']


### PR DESCRIPTION
This PR supports the following:
* Convert data object to string before making a request
* Temporary handle vcap services... This is a temporary change as we pass in only `service name`. So a VCAP service like `compare-and-comply` would be converted to `compare_and_comply`