### PR TITLE
Model conversion

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -206,10 +206,6 @@ class BaseService(object):
 
     @staticmethod
     def _convert_model(val, classname=None):
-        if classname is not None and not hasattr(val, "_from_dict"):
-            if isinstance(val, str):
-                val = json_import.loads(val)
-            val = classname._from_dict(dict(val))
         if hasattr(val, "_to_dict"):
             return val._to_dict()
         return val

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -205,10 +205,9 @@ class BaseService(object):
 
 
     @staticmethod
-    def _convert_model(val, classname=None):
-        if classname is not None:
-            if isinstance(val, str):
-                val = json_import.loads(val)
+    def _convert_model(val):
+        if isinstance(val, str):
+            val = json_import.loads(val)
         if hasattr(val, "_to_dict"):
             return val._to_dict()
         return val

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -206,6 +206,9 @@ class BaseService(object):
 
     @staticmethod
     def _convert_model(val, classname=None):
+        if classname is not None:
+            if isinstance(val, str):
+                val = json_import.loads(val)
         if hasattr(val, "_to_dict"):
             return val._to_dict()
         return val

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -343,7 +343,7 @@ def test_misc_methods():
     model1 = service._convert_model(mock)
     assert model1 == {'x': 'foo'}
 
-    model2 = service._convert_model("{\"x\": \"foo\"}", MockModel)
+    model2 = service._convert_model("{\"x\": \"foo\"}")
     assert model2 is not None
     assert model2['x'] == 'foo'
 


### PR DESCRIPTION
Now since the `x-alternate-name` is not present in the api definitions of major release, we can remove the `_from_dict ` step to avoid potential errors received especially in import/ export workspace