### PR TITLE
Logging and debugging

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -26,10 +26,9 @@ from .detailed_response import DetailedResponse
 from .api_exception import ApiException
 from .authenticators import Authenticator
 from http.cookiejar import CookieJar
-
-# Uncomment this to enable http debugging
-# import http.client as http_client
-# http_client.HTTPConnection.debuglevel = 1
+from http.client import HTTPConnection
+import logging
+import logging.config
 
 
 class BaseService(object):
@@ -53,6 +52,7 @@ class BaseService(object):
         self.authenticator = authenticator
         self.disable_ssl_verification = disable_ssl_verification
         self.default_headers = None
+        self.debug = False
 
         self._set_user_agent_header(self._build_user_agent())
 
@@ -203,6 +203,32 @@ class BaseService(object):
         request['files'] = files
         return request
 
+    def enable_debugging(self):
+        """
+        Enables the HTTPConnection.debuglevel print() statement
+        """
+        self.debug = True
+        HTTPConnection.debuglevel = 1
+
+    def disable_debugging(self):
+        """
+        Disables the HTTPConnection.debuglevel print() statement
+        """
+        self.debug = False
+        HTTPConnection.debuglevel = 0
+
+    def enable_logging(self, config_file_path):
+        """
+        :param str config_file_path: The config file path.
+        """
+        logging.config.fileConfig(
+            config_file_path, disable_existing_loggers=False)
+
+    def get_logger(self, name=None):
+        """
+        Returns the root logger if no name is provided
+        """
+        return logging.getLogger(name)
 
     @staticmethod
     def _convert_model(val):

--- a/resources/logging.conf
+++ b/resources/logging.conf
@@ -1,0 +1,23 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=Formatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler
+qualname=main
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=Formatter
+args=(sys.stdout,)
+
+[formatter_Formatter]
+format=%(asctime)s - %(levelname)s - %(message)s
+datefmt="%Y-%m-%d %H:%M:%S"

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -420,3 +420,18 @@ def test_json():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
     req = service.prepare_request('POST', url='', headers={'X-opt-out': True}, data={'hello': 'world'})
     assert req.get('data') == "{\"hello\": \"world\"}"
+
+def test_debugging():
+    service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
+    service.enable_debugging()
+    assert service.debug is True
+    service.disable_debugging()
+    assert service.debug is False
+
+def test_logging():
+    service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
+    log_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../resources/logging.conf')
+    service.enable_logging(log_file_path)
+
+    logger = service.get_logger()
+    assert logger is not None


### PR DESCRIPTION
This PR enables logging and debugging

* The underlying http urllib3 library doesn't use the logging, but rather print statement to stdout. functions `enable_debugging()` and `disable_debugging` is used to support it
* We also need to provide users with python's logging capabilities:
   1) `enable_logging` takes in a config file path
   2) `get_logger ` allows users to configure loggers

readme is updated here: https://github.com/watson-developer-cloud/python-sdk/pull/687