### PR TITLE
refactor: Simplify check for user-agent header in CaseInsensitiveDict

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -281,7 +281,7 @@ class BaseService:
         headers = CaseInsensitiveDict(headers)
         if self.default_headers is not None:
             headers.update(self.default_headers)
-        if not any(key in headers for key in ['user-agent', 'User-Agent']):
+        if 'user-agent' not in headers:
             headers.update(self.user_agent_header)
         request['headers'] = headers
 


### PR DESCRIPTION
This PR makes a minor change to the logic for adding a user-agent header to the request if one is not already present.  The prior logic checked for user-agent in two different case forms, but the `headers` object is a `CaseInsensitiveDict`, so this logic is unnecessary.  A simple check for any case of `user-agent` is sufficient. To illustrate:
```
Last login: Fri Nov 15 12:54:55 on ttys009
[mkistler@mkistlers-MacBook-Pro] ~>python3
Python 3.7.3 (default, May 18 2019, 07:14:44) 
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> from requests.structures import CaseInsensitiveDict
>>> headers = {'user-agent': 'foo'}
>>> headers = CaseInsensitiveDict(headers)
>>> 'user-agent' in headers
True
>>> 'User-agent' in headers
True
>>> 'User-Agent' in headers
True
>>> 
```