### PR TITLE
feat: expand vcap credential loading to support user-defined service names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ matrix:
     - python: 3.5
     - python: 3.6
     - python: 3.7
+    - python: 3.8
     
 dist: xenial
 


### PR DESCRIPTION
This PR serves two purposes:
1) Adds a commit with a properly-formatted commit message pertaining to the recent work to modify our VCAP_SERVICES function to support user-defined service names.
2) Adds python 3.8 to our list of versions that are used during Travis builds.   This list now includes 3.5, 3.6, 3.7 and 3.8.