### PR TITLE
chore: add --allow-dirty to bumpversion command

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,7 +5,7 @@
   "prepare": [
     {
       "path": "@semantic-release/exec",
-      "cmd": "bumpversion --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
+      "cmd": "bumpversion --allow-dirty --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
     },
     "@semantic-release/changelog",
     "@semantic-release/git"


### PR DESCRIPTION
This PR fixes a minor issue related to semantic-release where the package-lock.json file might be updated as the result of running semantic-release, resulting in a "dirty workspace" and semrel refuses to proceed.
Adding `--allow-dirty` to bumpversion command.