### PR TITLE
fix: Fix date/datetime_to_string handling of non-date/datetime inputs

### DIFF
--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -77,7 +77,9 @@ def datetime_to_string(val: datetime.datetime) -> str:
     Returns:
         datetime serialized to iso8601 format.
     """
-    return val.isoformat().replace('+00:00', 'Z')
+    if isinstance(val, datetime.datetime):
+        return val.isoformat().replace('+00:00', 'Z')
+    return val
 
 def string_to_datetime(string: str) -> datetime.datetime:
     """De-serializes string to datetime.
@@ -99,7 +101,9 @@ def date_to_string(val: datetime.date) -> str:
     Returns:
         date serialized to `YYYY-MM-DD` format.
     """
-    return str(val)
+    if isinstance(val, datetime.date):
+        return str(val)
+    return val
 
 def string_to_date(string: str) -> datetime.date:
     """De-serializes string to date.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -11,12 +11,14 @@ def test_datetime_conversion():
     assert date.day == 6
     res = datetime_to_string(date)
     assert res == '2017-03-06T16:00:04.159338'
+    assert datetime_to_string(None) is None
 
 def test_date_conversion():
     date = string_to_date('2017-03-06')
     assert date.day == 6
     res = date_to_string(date)
     assert res == '2017-03-06'
+    assert date_to_string(None) is None
 
 def test_convert_model():
 


### PR DESCRIPTION
This PR fixes the behavior of the recently added date/datetime_to_string methods to gracefully handle inputs that are not `date` or `datetime`.  Most importantly, these methods should return `None` if the input is `None`.  The new implementation simply returns the input argument whenever it is not of the expected type, which is consistent with the behavior of the other methods in the utils file.