### PR TITLE
Fix override of error message for 401 response

### DIFF
--- a/ibm_cloud_sdk_core/api_exception.py
+++ b/ibm_cloud_sdk_core/api_exception.py
@@ -64,6 +64,8 @@ class ApiException(Exception):
                 error_message = error_json['message']
             elif 'errorMessage' in error_json:
                 error_message = error_json['errorMessage']
+            elif response.status_code == 401:
+                error_message = 'Unauthorized: Access is denied due to invalid credentials'
             return error_message
         except:
             return response.text or error_message

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -221,12 +221,8 @@ class BaseService:
                 return DetailedResponse(result, response.headers,
                                         response.status_code)
 
-            error_message = None
-            if response.status_code == 401:
-                error_message = 'Unauthorized: Access is denied due to ' \
-                                'invalid credentials'
             raise ApiException(
-                response.status_code, error_message, http_response=response)
+                response.status_code, http_response=response)
         except requests.exceptions.SSLError:
             logging.exception(self.ERROR_MSG_DISABLE_SSL)
             raise


### PR DESCRIPTION
This PR fixes the override of the exception message for 401 error responses.  Previously the message was set unconditionally to a standard message in the SDK core.  Now that standard message is only used for 401 errors if no suitable error message is found in the response body.

Fixes #58.