### PR TITLE
[Breaking] Only override content-type if it is none

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -290,7 +290,8 @@ class BaseService:
 
         if data and isinstance(data, dict):
             data = remove_null_values(data)
-            headers.update({'content-type': 'application/json'})
+            if headers.get('content-type') is None:
+                headers.update({'content-type': 'application/json'})
             data = json_import.dumps(data)
         request['data'] = data
 


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1201

Currently the header `content-type` is unconditionally overridden to "application/json". This change will only add it if the header is not set.