### PR TITLE
Add type annotations to parameters and return values

### DIFF
--- a/ibm_cloud_sdk_core/api_exception.py
+++ b/ibm_cloud_sdk_core/api_exception.py
@@ -32,7 +32,7 @@ class ApiException(Exception):
         global_transaction_id (str, optional): Globally unique id the service endpoint has given a transaction.
     """
 
-    def __init__(self, code: int, *, message: Optional[str] = None, http_response: Optional[Response] = None):
+    def __init__(self, code: int, *, message: Optional[str] = None, http_response: Optional[Response] = None) -> None:
         # Call the base class constructor with the parameters it needs
         super(ApiException, self).__init__(message)
         self.message = message
@@ -43,14 +43,14 @@ class ApiException(Exception):
             self.global_transaction_id = http_response.headers.get('X-Global-Transaction-ID')
             self.message = self.message if self.message else self._get_error_message(http_response)
 
-    def __str__(self):
+    def __str__(self) -> str:
         msg = 'Error: ' + str(self.message) + ', Code: ' + str(self.code)
         if self.global_transaction_id is not None:
             msg += ' , X-global-transaction-id: ' + str(self.global_transaction_id)
         return  msg
 
     @staticmethod
-    def _get_error_message(response: Response):
+    def _get_error_message(response: Response) -> str:
         error_message = 'Unknown error'
         try:
             error_json = response.json()

--- a/ibm_cloud_sdk_core/api_exception.py
+++ b/ibm_cloud_sdk_core/api_exception.py
@@ -32,7 +32,7 @@ class ApiException(Exception):
         global_transaction_id (str, optional): Globally unique id the service endpoint has given a transaction.
     """
 
-    def __init__(self, code: int, message: Optional[str] = None, http_response: Optional[Response] = None):
+    def __init__(self, code: int, *, message: Optional[str] = None, http_response: Optional[Response] = None):
         # Call the base class constructor with the parameters it needs
         super(ApiException, self).__init__(message)
         self.message = message

--- a/ibm_cloud_sdk_core/authenticators/authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/authenticator.py
@@ -22,6 +22,9 @@ class Authenticator(ABC):
     def authenticate(self, req: dict) -> None:
         """Perform the necessary authentication steps for the specified request.
 
+        Attributes:
+            req (dict): Will be modified to contain the appropriate authentication information.
+
         To be implemented by subclasses.
         """
         pass
@@ -29,6 +32,9 @@ class Authenticator(ABC):
     @abstractmethod
     def validate(self) -> None:
         """Validates the current set of configuration information in the Authenticator.
+
+        Raises:
+            ValueError: The configuration information is not valid for service operations.
 
         To be implemented by subclasses.
         """

--- a/ibm_cloud_sdk_core/authenticators/authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/authenticator.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 class Authenticator(ABC):
     """This interface defines the common methods and constants associated with an Authenticator implementation."""
     @abstractmethod
-    def authenticate(self, req: dict):
+    def authenticate(self, req: dict) -> None:
         """Perform the necessary authentication steps for the specified request.
 
         To be implemented by subclasses.
@@ -27,7 +27,7 @@ class Authenticator(ABC):
         pass
 
     @abstractmethod
-    def validate(self):
+    def validate(self) -> None:
         """Validates the current set of configuration information in the Authenticator.
 
         To be implemented by subclasses.

--- a/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
@@ -62,7 +62,7 @@ class BasicAuthenticator(Authenticator):
                 'Please remove any surrounding {, }, or \" characters.')
 
 
-    def __construct_basic_auth_header(self) -> None:
+    def __construct_basic_auth_header(self) -> str:
         authstring = "{0}:{1}".format(self.username, self.password)
         base64_authorization = base64.b64encode(authstring.encode('utf-8')).decode('utf-8')
         return 'Basic {0}'.format(base64_authorization)

--- a/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
@@ -37,14 +37,14 @@ class BasicAuthenticator(Authenticator):
     """
     authentication_type = 'basic'
 
-    def __init__(self, username: str, password: str):
+    def __init__(self, username: str, password: str) -> None:
         self.username = username
         self.password = password
         self.validate()
         self.authorization_header = self.__construct_basic_auth_header()
 
 
-    def validate(self):
+    def validate(self) -> None:
         """Validate username and password.
 
         Ensure the username and password are valid for service operations.
@@ -62,13 +62,13 @@ class BasicAuthenticator(Authenticator):
                 'Please remove any surrounding {, }, or \" characters.')
 
 
-    def __construct_basic_auth_header(self):
+    def __construct_basic_auth_header(self) -> None:
         authstring = "{0}:{1}".format(self.username, self.password)
         base64_authorization = base64.b64encode(authstring.encode('utf-8')).decode('utf-8')
         return 'Basic {0}'.format(base64_authorization)
 
 
-    def authenticate(self, req: Request):
+    def authenticate(self, req: Request) -> None:
         """Add basic authentication information to a request.
 
         Basic Authorization will be added to the request's headers in the form:

--- a/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
@@ -34,11 +34,11 @@ class BearerTokenAuthenticator(Authenticator):
     """
     authentication_type = 'bearerToken'
 
-    def __init__(self, bearer_token: str):
+    def __init__(self, bearer_token: str) -> None:
         self.bearer_token = bearer_token
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Validate the bearer token.
 
         Ensures the bearer token is valid for service operations.
@@ -49,7 +49,7 @@ class BearerTokenAuthenticator(Authenticator):
         if self.bearer_token is None:
             raise ValueError('The bearer token shouldn\'t be None.')
 
-    def authenticate(self, req: Request):
+    def authenticate(self, req: Request) -> None:
         """Adds bearer authentication information to the request.
 
         The bearer token will be added to the request's headers in the form:
@@ -63,7 +63,7 @@ class BearerTokenAuthenticator(Authenticator):
         headers = req.get('headers')
         headers['Authorization'] = 'Bearer {0}'.format(self.bearer_token)
 
-    def set_bearer_token(self, bearer_token: str):
+    def set_bearer_token(self, bearer_token: str) -> None:
         """Set a new bearer token to be sent in subsequent service operations.
 
         Args:

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -61,7 +61,8 @@ class CloudPakForDataAuthenticator(Authenticator):
                  headers: Optional[Dict[str, str]] = None,
                  proxies: Optional[Dict[str, str]] = None):
         self.token_manager = CP4DTokenManager(
-            username, password, url, disable_ssl_verification, headers, proxies)
+            username, password, url, disable_ssl_verification=disable_ssl_verification,
+            headers=headers, proxies=proxies)
         self.validate()
 
     def validate(self):

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -56,6 +56,7 @@ class CloudPakForDataAuthenticator(Authenticator):
                  username: str,
                  password: str,
                  url: str,
+                 *,
                  disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
                  proxies: Optional[Dict[str, str]] = None):

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -59,13 +59,13 @@ class CloudPakForDataAuthenticator(Authenticator):
                  *,
                  disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
-                 proxies: Optional[Dict[str, str]] = None):
+                 proxies: Optional[Dict[str, str]] = None) -> None:
         self.token_manager = CP4DTokenManager(
             username, password, url, disable_ssl_verification=disable_ssl_verification,
             headers=headers, proxies=proxies)
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Validate username, password, and url for token requests.
 
         Ensures the username, password, and url are not None. Additionally, ensures they do not contain invalid
@@ -91,7 +91,7 @@ class CloudPakForDataAuthenticator(Authenticator):
                 'The url shouldn\'t start or end with curly brackets or quotes. '
                 'Please remove any surrounding {, }, or \" characters.')
 
-    def authenticate(self, req: Request):
+    def authenticate(self, req: Request) -> None:
         """Adds CP4D authentication information to the request.
 
         The CP4D bearer token will be added to the request's headers in the form:
@@ -106,7 +106,7 @@ class CloudPakForDataAuthenticator(Authenticator):
         bearer_token = self.token_manager.get_token()
         headers['Authorization'] = 'Bearer {0}'.format(bearer_token)
 
-    def set_disable_ssl_verification(self, status: bool = False):
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
         """Set the flag that indicates whether verification of the server's SSL certificate should be
         disabled or not. Defaults to False.
 
@@ -115,7 +115,7 @@ class CloudPakForDataAuthenticator(Authenticator):
         """
         self.token_manager.set_disable_ssl_verification(status)
 
-    def set_headers(self, headers: Dict[str, str]):
+    def set_headers(self, headers: Dict[str, str]) -> None:
         """Default headers to be sent with every CP4D token request.
 
         Args:
@@ -123,7 +123,7 @@ class CloudPakForDataAuthenticator(Authenticator):
         """
         self.token_manager.set_headers(headers)
 
-    def set_proxies(self, proxies: Dict[str, str]):
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
         """Sets the proxies the token manager will use to communicate with CP4D on behalf of the host.
 
         Args:

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -56,6 +56,7 @@ class IAMAuthenticator(Authenticator):
 
     def __init__(self,
                  apikey: str,
+                 *,
                  url: Optional[str] = None,
                  client_id: Optional[str] = None,
                  client_secret: Optional[str] = None,

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -62,14 +62,14 @@ class IAMAuthenticator(Authenticator):
                  client_secret: Optional[str] = None,
                  disable_ssl_verification: Optional[bool] = False,
                  headers: Optional[Dict[str, str]] = None,
-                 proxies: Optional[Dict[str, str]] = None):
+                 proxies: Optional[Dict[str, str]] = None) -> None:
         self.token_manager = IAMTokenManager(
             apikey, url=url, client_id=client_id, client_secret=client_secret,
             disable_ssl_verification=disable_ssl_verification,
             headers=headers, proxies=proxies)
         self.validate()
 
-    def validate(self):
+    def validate(self) -> None:
         """Validates the apikey, client_id, and client_secret for IAM token requests.
 
         Ensure the apikey is not none, and has no bad characters. Additionally, ensure the
@@ -93,7 +93,7 @@ class IAMAuthenticator(Authenticator):
             raise ValueError(
                 'Both client_id and client_secret should be initialized.')
 
-    def authenticate(self, req: Request):
+    def authenticate(self, req: Request) -> None:
         """Adds IAM authentication information to the request.
 
         The IAM bearer token will be added to the request's headers in the form:
@@ -108,7 +108,7 @@ class IAMAuthenticator(Authenticator):
         bearer_token = self.token_manager.get_token()
         headers['Authorization'] = 'Bearer {0}'.format(bearer_token)
 
-    def set_client_id_and_secret(self, client_id: str, client_secret: str):
+    def set_client_id_and_secret(self, client_id: str, client_secret: str) -> None:
         """Set the client_id and client_secret pair the token manager will use for IAM token requests.
 
         Args:
@@ -121,7 +121,7 @@ class IAMAuthenticator(Authenticator):
         self.token_manager.set_client_id_and_secret(client_id, client_secret)
         self.validate()
 
-    def set_disable_ssl_verification(self, status: bool = False):
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
         """Set the flag that indicates whether verification of the server's SSL certificate should be
         disabled or not. Defaults to False.
 
@@ -130,7 +130,7 @@ class IAMAuthenticator(Authenticator):
         """
         self.token_manager.set_disable_ssl_verification(status)
 
-    def set_headers(self, headers: Dict[str, str]):
+    def set_headers(self, headers: Dict[str, str]) -> None:
         """Headers to be sent with every IAM token request.
 
         Args:
@@ -138,7 +138,7 @@ class IAMAuthenticator(Authenticator):
         """
         self.token_manager.set_headers(headers)
 
-    def set_proxies(self, proxies: Dict[str, str]):
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
         """Sets the proxies the token manager will use to communicate with IAM on behalf of the host.
 
         Args:

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -64,8 +64,9 @@ class IAMAuthenticator(Authenticator):
                  headers: Optional[Dict[str, str]] = None,
                  proxies: Optional[Dict[str, str]] = None):
         self.token_manager = IAMTokenManager(
-            apikey, url, client_id, client_secret, disable_ssl_verification,
-            headers, proxies)
+            apikey, url=url, client_id=client_id, client_secret=client_secret,
+            disable_ssl_verification=disable_ssl_verification,
+            headers=headers, proxies=proxies)
         self.validate()
 
     def validate(self):

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -60,7 +60,7 @@ class IAMAuthenticator(Authenticator):
                  url: Optional[str] = None,
                  client_id: Optional[str] = None,
                  client_secret: Optional[str] = None,
-                 disable_ssl_verification: Optional[bool] = False,
+                 disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
                  proxies: Optional[Dict[str, str]] = None) -> None:
         self.token_manager = IAMTokenManager(

--- a/ibm_cloud_sdk_core/authenticators/no_auth_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/no_auth_authenticator.py
@@ -20,8 +20,8 @@ class NoAuthAuthenticator(Authenticator):
     """Performs no authentication."""
     authentication_type = 'noAuth'
 
-    def validate(self):
+    def validate(self) -> None:
         pass
 
-    def authenticate(self, req):
+    def authenticate(self, req) -> None:
         pass

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -65,6 +65,7 @@ class BaseService:
                             'disable_ssl_verification option of the authenticator.'
 
     def __init__(self,
+                 *,
                  service_url: str = None,
                  authenticator: Authenticator = None,
                  disable_ssl_verification: bool = False):
@@ -237,6 +238,7 @@ class BaseService:
     def prepare_request(self,
                         method: str,
                         url: str,
+                        *,
                         headers: Optional[dict] = None,
                         params: Optional[dict] = None,
                         data: Optional[Union[str, dict]] = None,

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -68,7 +68,7 @@ class BaseService:
                  *,
                  service_url: str = None,
                  authenticator: Authenticator = None,
-                 disable_ssl_verification: bool = False):
+                 disable_ssl_verification: bool = False) -> None:
         self.service_url = service_url
         self.http_config = {}
         self.jar = CookieJar()
@@ -83,18 +83,18 @@ class BaseService:
                 'authenticator should be of type Authenticator')
 
     @staticmethod
-    def _get_system_info():
+    def _get_system_info() -> str:
         return '{0} {1} {2}'.format(
             platform.system(),  # OS
             platform.release(),  # OS version
             platform.python_version()  # Python version
         )
 
-    def _build_user_agent(self):
+    def _build_user_agent(self) -> str:
         return '{0}-{1} {2}'.format(self.SDK_NAME, __version__,
                                     self._get_system_info())
 
-    def configure_service(self, service_name: str):
+    def configure_service(self, service_name: str) -> None:
         """Look for external configuration of a service. Set service properties.
 
         Try to get config from external sources, with the following priority:
@@ -119,10 +119,10 @@ class BaseService:
                 bool(config.get('DISABLE_SSL'))
             )
 
-    def _set_user_agent_header(self, user_agent_string=None):
+    def _set_user_agent_header(self, user_agent_string=None) -> None:
         self.user_agent_header = {'User-Agent': user_agent_string}
 
-    def set_http_config(self, http_config: dict):
+    def set_http_config(self, http_config: dict) -> None:
         """Sets the http config dictionary.
 
         The dictionary can contain values that control the timeout, proxies, and etc of HTTP requests.
@@ -141,7 +141,7 @@ class BaseService:
         else:
             raise TypeError("http_config parameter must be a dictionary")
 
-    def set_disable_ssl_verification(self, status: bool = False):
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
         """Set the flag that indicates whether verification of
         the server's SSL certificate should be disabled or not.
 
@@ -150,7 +150,7 @@ class BaseService:
         """
         self.disable_ssl_verification = status
 
-    def set_service_url(self, service_url: str):
+    def set_service_url(self, service_url: str) -> None:
         """Set the url the service will make HTTP requests too.
 
         Arguments:
@@ -174,7 +174,7 @@ class BaseService:
         """
         return self.authenticator
 
-    def set_default_headers(self, headers: Dict[str, str]):
+    def set_default_headers(self, headers: Dict[str, str]) -> None:
         """Set http headers to be sent in every request.
 
         Arguments:
@@ -338,7 +338,7 @@ class BaseService:
     # pylint: disable=protected-access
 
     @staticmethod
-    def _convert_model(val):
+    def _convert_model(val: str) -> None:
         if isinstance(val, str):
             val = json_import.loads(val)
         if hasattr(val, "_to_dict"):
@@ -346,11 +346,11 @@ class BaseService:
         return val
 
     @staticmethod
-    def _convert_list(val):
+    def _convert_list(val: list) -> None:
         if isinstance(val, list):
             return ",".join(val)
         return val
 
     @staticmethod
-    def _encode_path_vars(*args):
+    def _encode_path_vars(*args) -> None:
         return (requests.utils.quote(x, safe='') for x in args)

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -119,7 +119,7 @@ class BaseService:
                 bool(config.get('DISABLE_SSL'))
             )
 
-    def _set_user_agent_header(self, user_agent_string=None) -> None:
+    def _set_user_agent_header(self, user_agent_string: str) -> None:
         self.user_agent_header = {'User-Agent': user_agent_string}
 
     def set_http_config(self, http_config: dict) -> None:

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -219,8 +219,8 @@ class BaseService:
                         result = response.json()
                     except:
                         result = response
-                return DetailedResponse(result, response.headers,
-                                        response.status_code)
+                return DetailedResponse(response=result, headers=response.headers,
+                                        status_code=response.status_code)
 
             raise ApiException(
                 response.status_code, http_response=response)

--- a/ibm_cloud_sdk_core/cp4d_token_manager.py
+++ b/ibm_cloud_sdk_core/cp4d_token_manager.py
@@ -55,7 +55,7 @@ class CP4DTokenManager(JWTTokenManager):
                  *,
                  disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
-                 proxies: Optional[Dict[str, str]] = None):
+                 proxies: Optional[Dict[str, str]] = None) -> None:
         self.username = username
         self.password = password
         if url and not self.VALIDATE_AUTH_PATH in url:
@@ -78,7 +78,7 @@ class CP4DTokenManager(JWTTokenManager):
             proxies=self.proxies)
         return response
 
-    def set_headers(self, headers: Dict[str, str]):
+    def set_headers(self, headers: Dict[str, str]) -> None:
         """Headers to be sent with every CP4D token request.
 
         Args:
@@ -89,7 +89,7 @@ class CP4DTokenManager(JWTTokenManager):
         else:
             raise TypeError('headers must be a dictionary')
 
-    def set_proxies(self, proxies: Dict[str, str]):
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
         """Sets the proxies the token manager will use to communicate with CP4D on behalf of the host.
 
         Args:

--- a/ibm_cloud_sdk_core/cp4d_token_manager.py
+++ b/ibm_cloud_sdk_core/cp4d_token_manager.py
@@ -52,6 +52,7 @@ class CP4DTokenManager(JWTTokenManager):
                  username: str,
                  password: str,
                  url: str,
+                 *,
                  disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
                  proxies: Optional[Dict[str, str]] = None):

--- a/ibm_cloud_sdk_core/cp4d_token_manager.py
+++ b/ibm_cloud_sdk_core/cp4d_token_manager.py
@@ -62,8 +62,8 @@ class CP4DTokenManager(JWTTokenManager):
             url = url + '/v1/preauth/validateAuth'
         self.headers = headers
         self.proxies = proxies
-        super(CP4DTokenManager, self).__init__(url, disable_ssl_verification,
-                                               self.TOKEN_NAME)
+        super(CP4DTokenManager, self).__init__(url, disable_ssl_verification=disable_ssl_verification,
+                                               token_name=self.TOKEN_NAME)
 
     def request_token(self) -> dict:
         """Makes a request for a token.

--- a/ibm_cloud_sdk_core/detailed_response.py
+++ b/ibm_cloud_sdk_core/detailed_response.py
@@ -34,6 +34,7 @@ class DetailedResponse:
 
     """
     def __init__(self,
+                 *,
                  response: Optional[requests.Response] = None,
                  headers: Optional[Dict[str, str]] = None,
                  status_code: Optional[int] = None):

--- a/ibm_cloud_sdk_core/detailed_response.py
+++ b/ibm_cloud_sdk_core/detailed_response.py
@@ -37,7 +37,7 @@ class DetailedResponse:
                  *,
                  response: Optional[requests.Response] = None,
                  headers: Optional[Dict[str, str]] = None,
-                 status_code: Optional[int] = None):
+                 status_code: Optional[int] = None) -> None:
         self.result = response
         self.headers = headers
         self.status_code = status_code
@@ -66,7 +66,7 @@ class DetailedResponse:
         """
         return self.status_code
 
-    def _to_dict(self):
+    def _to_dict(self) -> dict:
         _dict = {}
         if hasattr(self, 'result') and self.result is not None:
             _dict['result'] = self.result if isinstance(self.result, (dict, list)) else 'HTTP response'
@@ -76,5 +76,5 @@ class DetailedResponse:
             _dict['status_code'] = self.status_code
         return _dict
 
-    def __str__(self):
+    def __str__(self) -> str:
         return json.dumps(self._to_dict(), indent=4, default=lambda o: o.__dict__)

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -38,7 +38,7 @@ def get_authenticator_from_environment(service_name: str) -> Authenticator:
         authenticator = __construct_authenticator(config)
     return authenticator
 
-def __construct_authenticator(config):
+def __construct_authenticator(config: dict) -> Authenticator:
     auth_type = config.get('AUTH_TYPE').lower() if config.get('AUTH_TYPE') else 'iam'
     authenticator = None
 

--- a/ibm_cloud_sdk_core/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/iam_token_manager.py
@@ -67,7 +67,7 @@ class IAMTokenManager(JWTTokenManager):
                  url: Optional[str] = None,
                  client_id: Optional[str] = None,
                  client_secret: Optional[str] = None,
-                 disable_ssl_verification: Optional[str] = False,
+                 disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
                  proxies: Optional[Dict[str, str]] = None) -> None:
         self.apikey = apikey

--- a/ibm_cloud_sdk_core/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/iam_token_manager.py
@@ -77,7 +77,7 @@ class IAMTokenManager(JWTTokenManager):
         self.headers = headers
         self.proxies = proxies
         super(IAMTokenManager, self).__init__(
-            self.url, disable_ssl_verification, self.TOKEN_NAME)
+            self.url, disable_ssl_verification=disable_ssl_verification, token_name=self.TOKEN_NAME)
 
     def request_token(self) -> dict:
         """Request an IAM OAuth token given an API Key.

--- a/ibm_cloud_sdk_core/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/iam_token_manager.py
@@ -63,6 +63,7 @@ class IAMTokenManager(JWTTokenManager):
 
     def __init__(self,
                  apikey: str,
+                 *,
                  url: Optional[str] = None,
                  client_id: Optional[str] = None,
                  client_secret: Optional[str] = None,

--- a/ibm_cloud_sdk_core/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/iam_token_manager.py
@@ -69,7 +69,7 @@ class IAMTokenManager(JWTTokenManager):
                  client_secret: Optional[str] = None,
                  disable_ssl_verification: Optional[str] = False,
                  headers: Optional[Dict[str, str]] = None,
-                 proxies: Optional[Dict[str, str]] = None):
+                 proxies: Optional[Dict[str, str]] = None) -> None:
         self.apikey = apikey
         self.url = url if url else self.DEFAULT_IAM_URL
         self.client_id = client_id
@@ -115,7 +115,7 @@ class IAMTokenManager(JWTTokenManager):
             proxies=self.proxies)
         return response
 
-    def set_client_id_and_secret(self, client_id: str, client_secret: str):
+    def set_client_id_and_secret(self, client_id: str, client_secret: str) -> None:
         """Set the client_id and client_secret.
 
         Args:
@@ -125,7 +125,7 @@ class IAMTokenManager(JWTTokenManager):
         self.client_id = client_id
         self.client_secret = client_secret
 
-    def set_headers(self, headers: Dict[str, str]):
+    def set_headers(self, headers: Dict[str, str]) -> None:
         """Headers to be sent with every CP4D token request.
 
         Args:
@@ -136,7 +136,7 @@ class IAMTokenManager(JWTTokenManager):
         else:
             raise TypeError('headers must be a dictionary')
 
-    def set_proxies(self, proxies: Dict[str, str]):
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
         """Sets the proxies the token manager will use to communicate with IAM on behalf of the host.
 
         Args:

--- a/ibm_cloud_sdk_core/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/jwt_token_manager.py
@@ -53,7 +53,7 @@ class JWTTokenManager:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, url: str, disable_ssl_verification: bool = False, token_name: Optional[str] = None):
+    def __init__(self, url: str, *, disable_ssl_verification: bool = False, token_name: Optional[str] = None):
         self.url = url
         self.disable_ssl_verification = disable_ssl_verification
         self.token_name = token_name
@@ -200,6 +200,7 @@ class JWTTokenManager:
     def _request(self,
                  method,
                  url,
+                 *,
                  headers=None,
                  params=None,
                  data=None,

--- a/ibm_cloud_sdk_core/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/jwt_token_manager.py
@@ -53,7 +53,7 @@ class JWTTokenManager:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, url: str, *, disable_ssl_verification: bool = False, token_name: Optional[str] = None):
+    def __init__(self, url: str, *, disable_ssl_verification: bool = False, token_name: Optional[str] = None) -> None:
         self.url = url
         self.disable_ssl_verification = disable_ssl_verification
         self.token_name = token_name
@@ -84,7 +84,7 @@ class JWTTokenManager:
 
         return self.token_info.get(self.token_name)
 
-    def set_disable_ssl_verification(self, status: bool = False):
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
         """Sets the ssl verification to enabled or disabled.
 
         Args:
@@ -92,7 +92,7 @@ class JWTTokenManager:
         """
         self.disable_ssl_verification = status
 
-    def paced_request_token(self):
+    def paced_request_token(self) -> None:
         """
         Paces requests to request_token.
 
@@ -128,7 +128,7 @@ class JWTTokenManager:
             time.sleep(0.5)  # Sleep for 0.5 seconds before checking token again
 
 
-    def request_token(self):
+    def request_token(self) -> None:
         """Should be overridden by child classes.
 
         Raises:
@@ -139,10 +139,10 @@ class JWTTokenManager:
         )
 
     @staticmethod
-    def _get_current_time():
+    def _get_current_time() -> int:
         return int(time.time())
 
-    def _is_token_expired(self):
+    def _is_token_expired(self) -> bool:
         """
         Check if currently stored token is expired.
 
@@ -154,7 +154,7 @@ class JWTTokenManager:
         current_time = self._get_current_time()
         return self.expire_time < current_time
 
-    def _token_needs_refresh(self):
+    def _token_needs_refresh(self) -> bool:
         """
         Check if currently stored token needs refresh.
 
@@ -172,7 +172,7 @@ class JWTTokenManager:
 
         return needs_refresh
 
-    def _save_token_info(self, token_response):
+    def _save_token_info(self, token_response: dict) -> None:
         """
         Decode the access token and save the response from the JWT service to the object's state
 
@@ -181,7 +181,7 @@ class JWTTokenManager:
 
         Parameters
         ----------
-        token_response : str
+        token_response : dict
             Response from token service
         """
         self.token_info = token_response

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -238,7 +238,7 @@ def __read_from_credential_file(service_name: str, *, separator: str = '=') -> d
                     _parse_key_and_update_config(config, service_name, key, value)
     return config
 
-def _parse_key_and_update_config(config, service_name, key, value):
+def _parse_key_and_update_config(config: dict, service_name: str, key: str, value: str) -> None:
     service_name = service_name.replace(' ', '_').replace('-', '_').upper()
     if key.startswith(service_name):
         config[key[len(service_name) + 1:]] = value

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -197,7 +197,7 @@ def __read_from_env_variables(service_name: str) -> dict:
         _parse_key_and_update_config(config, service_name, key, value)
     return config
 
-def __read_from_credential_file(service_name: str, separator: str = '=') -> dict:
+def __read_from_credential_file(service_name: str, *, separator: str = '=') -> dict:
     """Return a config object based on credentials file for a service.
 
     Args:

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -524,7 +524,7 @@ def test_service_url_not_set():
     assert str(err.value) == 'The service_url is required'
 
 def test_setting_proxy():
-    service = BaseService('test', authenticator=IAMAuthenticator('wonder woman'))
+    service = BaseService(service_url='test', authenticator=IAMAuthenticator('wonder woman'))
     assert service.authenticator is not None
     assert service.authenticator.token_manager.http_config == {}
 
@@ -536,7 +536,7 @@ def test_setting_proxy():
     service.set_http_config(http_config)
     assert service.authenticator.token_manager.http_config == http_config
 
-    service2 = BaseService('test', authenticator=BasicAuthenticator('marvellous', 'mrs maisel'))
+    service2 = BaseService(service_url='test', authenticator=BasicAuthenticator('marvellous', 'mrs maisel'))
     service2.set_http_config(http_config)
     assert service2.authenticator is not None
 
@@ -551,7 +551,7 @@ def test_configure_service():
     assert isinstance(service.get_authenticator(), NoAuthAuthenticator)
 
 def test_configure_service_error():
-    service = BaseService('v1', authenticator=NoAuthAuthenticator())
+    service = BaseService(service_url='v1', authenticator=NoAuthAuthenticator())
     with pytest.raises(ValueError) as err:
         service.configure_service(None)
     assert str(err.value) == 'Service_name must be of type string.'

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -7,22 +7,23 @@ from shutil import copyfile
 import pytest
 import responses
 import jwt
-from ibm_cloud_sdk_core import BaseService
+from ibm_cloud_sdk_core import BaseService, DetailedResponse
 from ibm_cloud_sdk_core import ApiException
 from ibm_cloud_sdk_core import CP4DTokenManager
 from ibm_cloud_sdk_core.authenticators import (IAMAuthenticator, NoAuthAuthenticator, Authenticator,
                                                BasicAuthenticator, CloudPakForDataAuthenticator)
 from ibm_cloud_sdk_core import get_authenticator_from_environment
+from typing import Optional
 
 
 class IncludeExternalConfigService(BaseService):
     default_service_url = 'https://servicesthatincludeexternalconfig.com/api'
     def __init__(
             self,
-            api_version,
-            authenticator=None,
-            trace_id=None
-        ):
+            api_version: str,
+            authenticator: Optional[Authenticator] = None,
+            trace_id: Optional[str] = None
+        ) -> None:
         BaseService.__init__(
             self,
             service_url=self.default_service_url,
@@ -38,11 +39,11 @@ class AnyServiceV1(BaseService):
 
     def __init__(
             self,
-            version,
-            service_url=default_url,
-            authenticator=None,
-            disable_ssl_verification=False
-        ):
+            version: str,
+            service_url: Optional[str] = default_url,
+            authenticator: Optional[Authenticator] = None,
+            disable_ssl_verification: Optional[bool] = False
+        ) -> None:
         BaseService.__init__(
             self,
             service_url=service_url,
@@ -50,7 +51,7 @@ class AnyServiceV1(BaseService):
             disable_ssl_verification=disable_ssl_verification)
         self.version = version
 
-    def op_with_path_params(self, path0, path1):
+    def op_with_path_params(self, path0: str, path1: str) -> DetailedResponse:
         if path0 is None:
             raise ValueError('path0 must be provided')
         if path1 is None:
@@ -62,24 +63,24 @@ class AnyServiceV1(BaseService):
         response = self.send(request)
         return response
 
-    def with_http_config(self, http_config):
+    def with_http_config(self, http_config: dict) -> DetailedResponse:
         self.set_http_config(http_config)
         request = self.prepare_request(method='GET', url='')
         response = self.send(request)
         return response
 
-    def any_service_call(self):
+    def any_service_call(self) -> DetailedResponse:
         request = self.prepare_request(method='GET', url='')
         response = self.send(request)
         return response
 
-    def head_request(self):
+    def head_request(self) -> DetailedResponse:
         request = self.prepare_request(method='HEAD', url='')
         response = self.send(request)
         return response
 
 
-def get_access_token():
+def get_access_token() -> str:
     access_token_layout = {
         "username": "dummy",
         "role": "Admin",

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -40,7 +40,7 @@ class AnyServiceV1(BaseService):
     def __init__(
             self,
             version: str,
-            service_url: Optional[str] = default_url,
+            service_url: str = default_url,
             authenticator: Optional[Authenticator] = None,
             disable_ssl_verification: bool = False
         ) -> None:

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -4,6 +4,7 @@ import json
 import time
 import os
 from shutil import copyfile
+from typing import Optional
 import pytest
 import responses
 import jwt
@@ -13,7 +14,6 @@ from ibm_cloud_sdk_core import CP4DTokenManager
 from ibm_cloud_sdk_core.authenticators import (IAMAuthenticator, NoAuthAuthenticator, Authenticator,
                                                BasicAuthenticator, CloudPakForDataAuthenticator)
 from ibm_cloud_sdk_core import get_authenticator_from_environment
-from typing import Optional
 
 
 class IncludeExternalConfigService(BaseService):

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -42,7 +42,7 @@ class AnyServiceV1(BaseService):
             version: str,
             service_url: Optional[str] = default_url,
             authenticator: Optional[Authenticator] = None,
-            disable_ssl_verification: Optional[bool] = False
+            disable_ssl_verification: bool = False
         ) -> None:
         BaseService.__init__(
             self,

--- a/test/test_detailed_response.py
+++ b/test/test_detailed_response.py
@@ -19,7 +19,8 @@ def test_detailed_response_dict():
                   content_type='application/json')
 
     mock_response = requests.get('https://test.com')
-    detailed_response = DetailedResponse(mock_response.json(), mock_response.headers, mock_response.status_code)
+    detailed_response = DetailedResponse(response=mock_response.json(), headers=mock_response.headers,
+                                         status_code=mock_response.status_code)
     assert detailed_response is not None
     assert detailed_response.get_result() == {'foobar': 'baz'}
     assert detailed_response.get_headers() == {u'Content-Type': 'application/json'}
@@ -39,7 +40,8 @@ def test_detailed_response_list():
                   content_type='application/json')
 
     mock_response = requests.get('https://test.com')
-    detailed_response = DetailedResponse(mock_response.json(), mock_response.headers, mock_response.status_code)
+    detailed_response = DetailedResponse(response=mock_response.json(), headers=mock_response.headers,
+                                         status_code=mock_response.status_code)
     assert detailed_response is not None
     assert detailed_response.get_result() == ['foobar', 'baz']
     assert detailed_response.get_headers() == {u'Content-Type': 'application/json'}

--- a/test/test_iam_token_manager.py
+++ b/test/test_iam_token_manager.py
@@ -60,7 +60,7 @@ def test_request_token_auth_in_ctor():
     default_auth_header = 'Basic Yng6Yng='
     responses.add(responses.POST, url=iam_url, body=response, status=200)
 
-    token_manager = IAMTokenManager("apikey", iam_url, 'foo', 'bar')
+    token_manager = IAMTokenManager("apikey", url=iam_url, client_id='foo', client_secret='bar')
     token_manager.request_token()
 
     assert len(responses.calls) == 1
@@ -112,7 +112,7 @@ def test_request_token_auth_in_ctor_client_id_only():
     }"""
     responses.add(responses.POST, url=iam_url, body=response, status=200)
 
-    token_manager = IAMTokenManager("iam_apikey", iam_url, 'foo')
+    token_manager = IAMTokenManager("iam_apikey", url=iam_url, client_id='foo')
     token_manager.request_token()
 
     assert len(responses.calls) == 1
@@ -132,7 +132,7 @@ def test_request_token_auth_in_ctor_secret_only():
     }"""
     responses.add(responses.POST, url=iam_url, body=response, status=200)
 
-    token_manager = IAMTokenManager("iam_apikey", iam_url, None, 'bar')
+    token_manager = IAMTokenManager("iam_apikey", url=iam_url, client_id=None, client_secret='bar')
     token_manager.request_token()
 
     assert len(responses.calls) == 1

--- a/test/test_iam_token_manager.py
+++ b/test/test_iam_token_manager.py
@@ -7,7 +7,7 @@ import pytest
 
 from ibm_cloud_sdk_core import IAMTokenManager, ApiException
 
-def get_access_token():
+def get_access_token() -> str:
     access_token_layout = {
         "username": "dummy",
         "role": "Admin",

--- a/test/test_jwt_token_manager.py
+++ b/test/test_jwt_token_manager.py
@@ -11,7 +11,8 @@ class JWTTokenManagerMockImpl(JWTTokenManager):
         self.url = url
         self.access_token = access_token
         self.request_count = 0 # just for tests to see how  many times request was called
-        super(JWTTokenManagerMockImpl, self).__init__(url, disable_ssl_verification=access_token, token_name='access_token')
+        super(JWTTokenManagerMockImpl, self).__init__(url, disable_ssl_verification=access_token,
+                                                      token_name='access_token')
 
     def request_token(self):
         self.request_count += 1

--- a/test/test_jwt_token_manager.py
+++ b/test/test_jwt_token_manager.py
@@ -4,17 +4,18 @@ import threading
 import jwt
 import pytest
 
-from ibm_cloud_sdk_core import JWTTokenManager
+from ibm_cloud_sdk_core import JWTTokenManager, DetailedResponse
+from typing import Optional
 
 class JWTTokenManagerMockImpl(JWTTokenManager):
-    def __init__(self, url=None, access_token=None):
+    def __init__(self, url: Optional[str] = None, access_token: Optional[str] = None) -> None:
         self.url = url
         self.access_token = access_token
         self.request_count = 0 # just for tests to see how  many times request was called
         super(JWTTokenManagerMockImpl, self).__init__(url, disable_ssl_verification=access_token,
                                                       token_name='access_token')
 
-    def request_token(self):
+    def request_token(self) -> DetailedResponse:
         self.request_count += 1
         current_time = int(time.time())
         token_layout = {
@@ -44,7 +45,7 @@ class JWTTokenManagerMockImpl(JWTTokenManager):
         time.sleep(0.5)
         return response
 
-def _get_current_time():
+def _get_current_time() -> int:
     return int(time.time())
 
 def test_get_token():

--- a/test/test_jwt_token_manager.py
+++ b/test/test_jwt_token_manager.py
@@ -11,7 +11,7 @@ class JWTTokenManagerMockImpl(JWTTokenManager):
         self.url = url
         self.access_token = access_token
         self.request_count = 0 # just for tests to see how  many times request was called
-        super(JWTTokenManagerMockImpl, self).__init__(url, access_token, 'access_token')
+        super(JWTTokenManagerMockImpl, self).__init__(url, disable_ssl_verification=access_token, token_name='access_token')
 
     def request_token(self):
         self.request_count += 1
@@ -81,7 +81,7 @@ def test_paced_get_token():
     assert token_manager.request_count == 1
 
 def test_is_token_expired():
-    token_manager = JWTTokenManagerMockImpl(None, None)
+    token_manager = JWTTokenManagerMockImpl(None, access_token=None)
     assert token_manager._is_token_expired() is True
     token_manager.expire_time = _get_current_time() + 3600
     assert token_manager._is_token_expired() is False
@@ -90,7 +90,7 @@ def test_is_token_expired():
 
 def test_not_implemented_error():
     with pytest.raises(NotImplementedError) as err:
-        token_manager = JWTTokenManager(None, None)
+        token_manager = JWTTokenManager(None, disable_ssl_verification=None)
         token_manager.request_token()
     assert str(err.value) == 'request_token MUST be overridden by a subclass of JWTTokenManager.'
 

--- a/test/test_jwt_token_manager.py
+++ b/test/test_jwt_token_manager.py
@@ -1,11 +1,11 @@
 # pylint: disable=missing-docstring,protected-access
 import time
 import threading
+from typing import Optional
 import jwt
 import pytest
 
 from ibm_cloud_sdk_core import JWTTokenManager, DetailedResponse
-from typing import Optional
 
 class JWTTokenManagerMockImpl(JWTTokenManager):
     def __init__(self, url: Optional[str] = None, access_token: Optional[str] = None) -> None:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,6 +6,7 @@ from ibm_cloud_sdk_core import string_to_datetime, datetime_to_string, get_authe
 from ibm_cloud_sdk_core import string_to_date, date_to_string
 from ibm_cloud_sdk_core import convert_model, convert_list
 from ibm_cloud_sdk_core.authenticators import BasicAuthenticator, IAMAuthenticator
+from typing import Optional
 
 def test_string_to_datetime():
     # If the specified string does not include a timezone, it is assumed to be UTC
@@ -52,10 +53,10 @@ def test_convert_model():
 
     class MockModel:
 
-        def __init__(self, xyz=None):
+        def __init__(self, xyz: Optional[str] = None) -> None:
             self.xyz = xyz
 
-        def to_dict(self):
+        def to_dict(self) -> dict:
             _dict = {}
             if hasattr(self, 'xyz') and self.xyz is not None:
                 _dict['xyz'] = self.xyz

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,11 +2,11 @@
 import datetime
 import os
 
+from typing import Optional
 from ibm_cloud_sdk_core import string_to_datetime, datetime_to_string, get_authenticator_from_environment
 from ibm_cloud_sdk_core import string_to_date, date_to_string
 from ibm_cloud_sdk_core import convert_model, convert_list
 from ibm_cloud_sdk_core.authenticators import BasicAuthenticator, IAMAuthenticator
-from typing import Optional
 
 def test_string_to_datetime():
     # If the specified string does not include a timezone, it is assumed to be UTC


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1598

Add Python 3.5 type annotations to parameters and return values.

I merged PR #61 into this branch so it includes those changes until I rebase when it is merged into `v2`.