### PR TITLE
fix: allow '=' character in environment config values

### DIFF
--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -231,7 +231,7 @@ def __read_from_credential_file(service_name: str, *, separator: str = '=') -> d
     if credential_file_path is not None:
         with open(credential_file_path, 'r') as fobj:
             for line in fobj:
-                key_val = line.strip().split(separator)
+                key_val = line.strip().split(separator, 1)
                 if len(key_val) == 2:
                     key = key_val[0]
                     value = key_val[1]

--- a/resources/ibm-credentials.env
+++ b/resources/ibm-credentials.env
@@ -2,3 +2,11 @@ IBM_WATSON_APIKEY=5678efgh
 IBM_WATSON_AUTH_TYPE=iam
 IBM_WATSON_URL=https://cwdserviceurl
 IBM_WATSON_DISABLE_SSL=False
+
+# Service1 auth properties configured with IAM and a token containing '='
+SERVICE_1_AUTH_TYPE=iam
+SERVICE_1_APIKEY=V4HXmoUtMjohnsnow=KotN
+SERVICE_1_CLIENT_ID=somefake========id
+SERVICE_1_CLIENT_SECRET===my-client-secret==
+SERVICE_1_AUTH_URL=https://iamhost/iam/api=
+SERVICE_1_URL=service1.com/api


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1759

Changes:
- allow for a env config property's value to contain the ``=`` character
- add unit test cases