### PR TITLE
fix: Strip trailing slash for request url

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -69,7 +69,7 @@ class BaseService:
                  service_url: str = None,
                  authenticator: Authenticator = None,
                  disable_ssl_verification: bool = False) -> None:
-        self.service_url = service_url
+        self.set_service_url(service_url)
         self.http_config = {}
         self.jar = CookieJar()
         self.authenticator = authenticator
@@ -164,7 +164,7 @@ class BaseService:
                 'The service url shouldn\'t start or end with curly brackets or quotes. '
                 'Be sure to remove any {} and \" characters surrounding your service url'
             )
-        self.service_url = service_url
+        self.service_url = service_url.rstrip('/') # remove trailing slash
 
     def get_authenticator(self) -> Authenticator:
         """Get the authenticator currently used by the service.
@@ -272,7 +272,7 @@ class BaseService:
         # validate the service url is set
         if not self.service_url:
             raise ValueError('The service_url is required')
-        request['url'] = self.service_url + url
+        request['url'] = self.service_url + url.rstrip('/') # strip trailing slash
 
         headers = remove_null_values(headers) if headers else {}
         headers = cleanup_values(headers)

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -518,6 +518,37 @@ def test_json():
     req = service.prepare_request('POST', url='', headers={'X-opt-out': True}, data={'hello': 'world'})
     assert req.get('data') == "{\"hello\": \"world\"}"
 
+def test_trailing_slash():
+    service = AnyServiceV1('2018-11-20', service_url='https://trailingSlash.com/', authenticator=NoAuthAuthenticator())
+    assert service.service_url == 'https://trailingSlash.com'
+    service.set_service_url('https://trailingSlash.com/')
+    assert service.service_url == 'https://trailingSlash.com'
+    req = service.prepare_request('POST',
+                                  url='/trailingSlashPath/',
+                                  headers={'X-opt-out': True},
+                                  data={'hello': 'world'})
+    assert req.get('url') == 'https://trailingSlash.com/trailingSlashPath'
+
+    service = AnyServiceV1('2018-11-20', service_url='https://trailingSlash.com/', authenticator=NoAuthAuthenticator())
+    assert service.service_url == 'https://trailingSlash.com'
+    service.set_service_url('https://trailingSlash.com/')
+    assert service.service_url == 'https://trailingSlash.com'
+    req = service.prepare_request('POST',
+                                  url='/',
+                                  headers={'X-opt-out': True},
+                                  data={'hello': 'world'})
+    assert req.get('url') == 'https://trailingSlash.com'
+
+    service = AnyServiceV1('2018-11-20', service_url='/', authenticator=NoAuthAuthenticator())
+    assert service.service_url == ''
+    service.set_service_url('/')
+    assert service.service_url == ''
+    with pytest.raises(ValueError): # ValueError thrown because service_url is '' and falsey
+        req = service.prepare_request('POST',
+                                      url='/',
+                                      headers={'X-opt-out': True},
+                                      data={'hello': 'world'})
+
 def test_service_url_not_set():
     service = BaseService(service_url='', authenticator=NoAuthAuthenticator())
     with pytest.raises(ValueError) as err:


### PR DESCRIPTION
Covered extra cases where trailing slash was not being removed when making a request.