### PR TITLE
refactor: 💡 Refactor JWTTokenManager to introduce TokenManager

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -29,7 +29,7 @@ from .version import __version__
 from .utils import has_bad_first_or_last_char, remove_null_values, cleanup_values, read_external_sources
 from .detailed_response import DetailedResponse
 from .api_exception import ApiException
-from .jwt_token_manager import JWTTokenManager
+from .token_manager import TokenManager
 
 # Uncomment this to enable http debugging
 # import http.client as http_client
@@ -136,7 +136,7 @@ class BaseService:
         if isinstance(http_config, dict):
             self.http_config = http_config
             if (self.authenticator and hasattr(self.authenticator, 'token_manager') and
-                    isinstance(self.authenticator.token_manager, JWTTokenManager)):
+                    isinstance(self.authenticator.token_manager, TokenManager)):
                 self.authenticator.token_manager.http_config = http_config
         else:
             raise TypeError("http_config parameter must be a dictionary")

--- a/ibm_cloud_sdk_core/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/jwt_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2019 IBM All Rights Reserved.
+# Copyright 2019, 2020 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,16 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-from threading import Lock
+from abc import ABC
 from typing import Optional
 
 import jwt
 import requests
 from .api_exception import ApiException
+from .token_manager import TokenManager
 
 
-class JWTTokenManager:
+# pylint: disable=too-many-instance-attributes
+
+
+class JWTTokenManager(TokenManager, ABC):
     """An abstract class to contain functionality for parsing, storing, and requesting JWT tokens.
 
     get_token will retrieve a new token from the url in case the that there is no existing token,
@@ -44,151 +47,28 @@ class JWTTokenManager:
         the server's SSL certificate should be disabled or not.
         token_name (str): The key used of the token in the dict returned from request_token.
         token_info (dict): The most token_response from request_token.
-        expire_time (int): The time in epoch seconds when the current token within token_info will expire.
-        refresh_time (int): The time in epoch seconds when the current token within token_info should be refreshed.
-        request_time (int): The time the last outstanding token request was issued
-        lock (Lock): Lock variable to serialize access to refresh/request times
-        http_config (dict): A dictionary containing values that control the timeout, proxies, and etc of HTTP requests.
     """
 
-    # pylint: disable=too-many-instance-attributes
-
-    def __init__(self, url: str, *, disable_ssl_verification: bool = False, token_name: Optional[str] = None) -> None:
-        self.url = url
-        self.disable_ssl_verification = disable_ssl_verification
+    def __init__(self, url: str, *, disable_ssl_verification: bool = False, token_name: Optional[str] = None):
+        super().__init__(url, disable_ssl_verification=disable_ssl_verification)
         self.token_name = token_name
         self.token_info = {}
-        self.expire_time = 0
-        self.refresh_time = 0
-        self.request_time = 0
-        self.lock = Lock()
-        self.http_config = {}
-
-    def get_token(self) -> str:
-        """Get a token to be used for authentication.
-
-        The source of the token is determined by the following logic:
-        1.  a) If the current token is expired (or never fetched), make a request for one
-            b) If the curent token should be refreshed, issue a refresh request
-        2. After any requests initiated above complete, return the stored token
-
-        Returns:
-            str: A valid access token
-        """
-        if self._is_token_expired():
-            self.paced_request_token()
-
-        if self._token_needs_refresh():
-            token_response = self.request_token()
-            self._save_token_info(token_response)
-
-        return self.token_info.get(self.token_name)
-
-    def set_disable_ssl_verification(self, status: bool = False) -> None:
-        """Sets the ssl verification to enabled or disabled.
-
-        Args:
-            status: the flag to be used for determining status.
-        """
-        self.disable_ssl_verification = status
-
-    def paced_request_token(self) -> None:
-        """
-        Paces requests to request_token.
-
-        This method pseudo-serializes requests for an access_token
-        when the current token is expired (or has never been fetched).
-        The first caller into this method records its `request_time` and
-        then issues the token request. Subsequent callers will check the
-        `request_time` to see if a request is active (has been issued within
-        the past 60 seconds), and if so will sleep for a short time interval
-        (currently 0.5 seconds) before checking again. The check for an active
-        request and update of `request_time` are serailized by the `lock`
-        variable so that only one caller can become the active requester
-        with a 60 second interval.
-
-        Threads that sleep waiting for the active request to complete will
-        eventually find a newly valid token and return, or 60 seconds will
-        elapse and a new thread will assume the role of the active request.
-        """
-        while self._is_token_expired():
-            current_time = self._get_current_time()
-
-            with self.lock:
-                request_active = self.request_time > (current_time - 60)
-                if not request_active:
-                    self.request_time = current_time
-
-            if not request_active:
-                token_response = self.request_token()
-                self._save_token_info(token_response)
-                self.request_time = 0
-                return
-
-            time.sleep(0.5)  # Sleep for 0.5 seconds before checking token again
-
-
-    def request_token(self) -> None:
-        """Should be overridden by child classes.
-
-        Raises:
-            NotImplementedError: Thrown when called.
-        """
-        raise NotImplementedError(
-            'request_token MUST be overridden by a subclass of JWTTokenManager.'
-        )
-
-    @staticmethod
-    def _get_current_time() -> int:
-        return int(time.time())
-
-    def _is_token_expired(self) -> bool:
-        """
-        Check if currently stored token is expired.
-
-        Returns
-        -------
-        bool
-            True if token is expired; False otherwise
-        """
-        current_time = self._get_current_time()
-        return self.expire_time < current_time
-
-    def _token_needs_refresh(self) -> bool:
-        """
-        Check if currently stored token needs refresh.
-
-        Returns
-        -------
-        bool
-            True if token needs refresh; False otherwise
-        """
-        current_time = self._get_current_time()
-
-        with self.lock:
-            needs_refresh = self.refresh_time < current_time
-            if needs_refresh:
-                self.refresh_time = current_time + 60
-
-        return needs_refresh
 
     def _save_token_info(self, token_response: dict) -> None:
         """
         Decode the access token and save the response from the JWT service to the object's state
-
         Refresh time is set to approximately 80% of the token's TTL to ensure that
         the token refresh completes before the current token expires.
-
         Parameters
         ----------
         token_response : dict
             Response from token service
         """
         self.token_info = token_response
-        access_token = token_response.get(self.token_name)
+        self.access_token = token_response.get(self.token_name)
 
         # The time of expiration is found by decoding the JWT access token
-        decoded_response = jwt.decode(access_token, verify=False)
+        decoded_response = jwt.decode(self.access_token, verify=False)
         # exp is the time of expire and iat is the time of token retrieval
         exp = decoded_response.get('exp')
         iat = decoded_response.get('iat')

--- a/ibm_cloud_sdk_core/token_manager.py
+++ b/ibm_cloud_sdk_core/token_manager.py
@@ -1,0 +1,214 @@
+# coding: utf-8
+
+# Copyright 2020 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from abc import ABC, abstractmethod
+from threading import Lock
+
+import time
+import requests
+
+from .api_exception import ApiException
+
+
+# pylint: disable=too-many-instance-attributes
+
+class TokenManager(ABC):
+    """An abstract class to contain functionality for parsing, storing, and requesting tokens.
+
+    get_token will retrieve a new token from the url in case the that there is no existing token,
+    or the previous token has expired. Child classes will implement request_token, which will do
+    the actual acquisition of a new token.
+
+    Args:
+        url: The url to request tokens from.
+
+    Keyword Args:
+        disable_ssl_verification: A flag that indicates whether verification of
+            the server's SSL certificate should be disabled or not. Defaults to False.
+
+    Attributes:
+        url (str): The url to request tokens from.
+        disable_ssl_verification (bool): A flag that indicates whether verification of
+        the server's SSL certificate should be disabled or not.
+        expire_time (int): The time in epoch seconds when the current stored token will expire.
+        refresh_time (int): The time in epoch seconds when the current stored token should be refreshed.
+        request_time (int): The time the last outstanding token request was issued
+        lock (Lock): Lock variable to serialize access to refresh/request times
+        http_config (dict): A dictionary containing values that control the timeout, proxies, and etc of HTTP requests.
+        access_token (str): The latest stored access token
+    """
+
+    def __init__(
+            self,
+            url: str,
+            *,
+            disable_ssl_verification: bool = False
+    ):
+        self.url = url
+        self.disable_ssl_verification = disable_ssl_verification
+        self.expire_time = 0
+        self.refresh_time = 0
+        self.request_time = 0
+        self.lock = Lock()
+        self.http_config = {}
+        self.access_token = None
+
+    def get_token(self) -> str:
+        """Get a token to be used for authentication.
+
+        The source of the token is determined by the following logic:
+        1.  a) If the current token is expired (or never fetched), make a request for one
+            b) If the current token should be refreshed, issue a refresh request
+        2. After any requests initiated above complete, return the stored token
+
+        Returns:
+            str: A valid access token
+        """
+        if self._is_token_expired():
+            self.paced_request_token()
+
+        if self._token_needs_refresh():
+            token_response = self.request_token()
+            self._save_token_info(token_response)
+
+        return self.access_token
+
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
+        """Sets the ssl verification to enabled or disabled.
+
+        Args:
+            status: the flag to be used for determining status.
+        """
+        self.disable_ssl_verification = status
+
+    def paced_request_token(self) -> None:
+        """
+        Paces requests to request_token.
+
+        This method pseudo-serializes requests for an access_token
+        when the current token is expired (or has never been fetched).
+        The first caller into this method records its `request_time` and
+        then issues the token request. Subsequent callers will check the
+        `request_time` to see if a request is active (has been issued within
+        the past 60 seconds), and if so will sleep for a short time interval
+        (currently 0.5 seconds) before checking again. The check for an active
+        request and update of `request_time` are serailized by the `lock`
+        variable so that only one caller can become the active requester
+        with a 60 second interval.
+
+        Threads that sleep waiting for the active request to complete will
+        eventually find a newly valid token and return, or 60 seconds will
+        elapse and a new thread will assume the role of the active request.
+        """
+        while self._is_token_expired():
+            current_time = self._get_current_time()
+
+            with self.lock:
+                request_active = self.request_time > (current_time - 60)
+                if not request_active:
+                    self.request_time = current_time
+
+            if not request_active:
+                token_response = self.request_token()
+                self._save_token_info(token_response)
+                self.request_time = 0
+                return
+
+            # Sleep for 0.5 seconds before checking token again
+            time.sleep(0.5)
+
+    @abstractmethod  # pragma: no cover
+    def request_token(self) -> None:
+        """Should be overridden by child classes."""
+        pass
+
+    @staticmethod
+    def _get_current_time() -> int:
+        return int(time.time())
+
+    def _is_token_expired(self) -> bool:
+        """
+        Check if currently stored token is expired.
+
+        Returns
+        -------
+        bool
+            True if token is expired; False otherwise
+        """
+        current_time = self._get_current_time()
+        return self.expire_time < current_time
+
+    def _token_needs_refresh(self) -> bool:
+        """
+        Check if currently stored token needs refresh.
+
+        Returns
+        -------
+        bool
+            True if token needs refresh; False otherwise
+        """
+        current_time = self._get_current_time()
+
+        with self.lock:
+            needs_refresh = self.refresh_time < current_time
+            if needs_refresh:
+                self.refresh_time = current_time + 60
+
+        return needs_refresh
+
+    @abstractmethod
+    def _save_token_info(self, token_response: dict) -> None:  # pragma: no cover
+        """
+        Decode the access token and save the response from the service to the object's state
+
+        Refresh time is set to approximately 80% of the token's TTL to ensure that
+        the token refresh completes before the current token expires.
+
+        Parameters
+        ----------
+        token_response : dict
+            Response from token service
+        """
+        pass
+
+    def _request(self,
+                 method,
+                 url,
+                 *,
+                 headers=None,
+                 params=None,
+                 data=None,
+                 auth_tuple=None,
+                 **kwargs):
+        kwargs = dict({"timeout": 60}, **kwargs)
+        kwargs = dict(kwargs, **self.http_config)
+
+        if self.disable_ssl_verification:
+            kwargs['verify'] = False
+
+        response = requests.request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            data=data,
+            auth=auth_tuple,
+            **kwargs)
+        if 200 <= response.status_code <= 299:
+            return response
+
+        raise ApiException(response.status_code, http_response=response)

--- a/test/test_jwt_token_manager.py
+++ b/test/test_jwt_token_manager.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,protected-access
+# pylint: disable=missing-docstring,protected-access,abstract-class-instantiated
 import time
 import threading
 from typing import Optional
@@ -51,7 +51,7 @@ def _get_current_time() -> int:
 def test_get_token():
     url = "https://iam.cloud.ibm.com/identity/token"
     token_manager = JWTTokenManagerMockImpl(url)
-    token = token_manager.get_token()
+    old_token = token_manager.get_token()
     assert token_manager.token_info.get('expires_in') == 3600
     assert token_manager._is_token_expired() is False
 
@@ -62,7 +62,7 @@ def test_get_token():
                                 "refresh_token": "jy4gl91BQ"
                                }
     token = token_manager.get_token()
-    assert token == "old_dummy"
+    assert token == old_token
 
     # expired token:
     token_manager.expire_time = _get_current_time() - 300
@@ -90,11 +90,12 @@ def test_is_token_expired():
     token_manager.expire_time = _get_current_time() - 3600
     assert token_manager._is_token_expired()
 
-def test_not_implemented_error():
-    with pytest.raises(NotImplementedError) as err:
-        token_manager = JWTTokenManager(None, disable_ssl_verification=None)
-        token_manager.request_token()
-    assert str(err.value) == 'request_token MUST be overridden by a subclass of JWTTokenManager.'
+def test_abstract_class_instantiation():
+    with pytest.raises(TypeError) as err:
+        JWTTokenManager(None)
+    assert str(err.value) == "Can't instantiate abstract class " \
+                             "JWTTokenManager with abstract methods " \
+                             "request_token"
 
 def test_disable_ssl_verification():
     token_manager = JWTTokenManagerMockImpl('https://iam.cloud.ibm.com/identity/token')

--- a/test/test_token_manager.py
+++ b/test/test_token_manager.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+
+# Copyright 2020 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring,protected-access,abstract-class-instantiated
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from ibm_cloud_sdk_core import ApiException
+from ibm_cloud_sdk_core.token_manager import TokenManager
+
+
+class MockTokenManager(TokenManager):
+
+    def request_token(self) -> None:
+        response = self._request(
+            method='GET',
+            url=self.url
+        )
+        return response
+
+    def _save_token_info(self, token_response: dict) -> None:
+        pass
+
+
+def test_abstract_class_instantiation():
+    with pytest.raises(TypeError) as err:
+        TokenManager(None)
+    assert str(err.value) == "Can't instantiate abstract class " \
+                             "TokenManager with abstract methods " \
+                             "_save_token_info, " \
+                             "request_token"
+
+
+def requests_request_spy(*args, **kwargs):
+    return SimpleNamespace(status_code=200, request_args=args, request_kwargs=kwargs)
+
+
+@mock.patch('requests.request', side_effect=requests_request_spy)
+def test_request_passes_disable_ssl_verification(request):  # pylint: disable=unused-argument
+    mock_token_manager = MockTokenManager(url="https://example.com", disable_ssl_verification=True)
+    assert mock_token_manager.request_token().request_kwargs['verify'] is False
+
+
+def requests_request_error_mock(*args, **kwargs):  # pylint: disable=unused-argument
+    return SimpleNamespace(status_code=300, headers={}, text="")
+
+
+@mock.patch('requests.request', side_effect=requests_request_error_mock)
+def test_request_raises_for_non_2xx(request):  # pylint: disable=unused-argument
+    mock_token_manager = MockTokenManager(url="https://example.com", disable_ssl_verification=True)
+    with pytest.raises(ApiException):
+        mock_token_manager.request_token()


### PR DESCRIPTION
Currently, JWTTokenManager is the top-most token manager class which
does not allow introducing new token managers in code that uses the IBM
Python SDK Core.

This commit refactors JWTTokenManager into an abstract
base class of TokenManager and the JWT-specific parts to allow extending
the Python SDK Core with non-JWT token managers.

This PR is analogous to https://github.com/IBM/node-sdk-core/pull/89