### PR TITLE
fix: Don't rstrip slash when service_url is none

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -164,7 +164,10 @@ class BaseService:
                 'The service url shouldn\'t start or end with curly brackets or quotes. '
                 'Be sure to remove any {} and \" characters surrounding your service url'
             )
-        self.service_url = service_url.rstrip('/') # remove trailing slash
+        if service_url is not None:
+            self.service_url = service_url.rstrip('/') # remove trailing slash
+        else:
+            self.service_url = None
 
     def get_authenticator(self) -> Authenticator:
         """Get the authenticator currently used by the service.

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -539,6 +539,9 @@ def test_trailing_slash():
                                   data={'hello': 'world'})
     assert req.get('url') == 'https://trailingSlash.com'
 
+    service.set_service_url(None)
+    assert service.service_url is None
+
     service = AnyServiceV1('2018-11-20', service_url='/', authenticator=NoAuthAuthenticator())
     assert service.service_url == ''
     service.set_service_url('/')


### PR DESCRIPTION
When service_url is none, rstrip will fail, this keeps the functionality before rstrip was added.