### PR TITLE
fix: Revert service_url slash stripping to work with current tests

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -164,10 +164,7 @@ class BaseService:
                 'The service url shouldn\'t start or end with curly brackets or quotes. '
                 'Be sure to remove any {} and \" characters surrounding your service url'
             )
-        if service_url is not None:
-            self.service_url = service_url.rstrip('/') # remove trailing slash
-        else:
-            self.service_url = None
+        self.service_url = service_url
 
     def get_authenticator(self) -> Authenticator:
         """Get the authenticator currently used by the service.

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -520,37 +520,37 @@ def test_json():
 
 def test_trailing_slash():
     service = AnyServiceV1('2018-11-20', service_url='https://trailingSlash.com/', authenticator=NoAuthAuthenticator())
-    assert service.service_url == 'https://trailingSlash.com'
+    assert service.service_url == 'https://trailingSlash.com/'
     service.set_service_url('https://trailingSlash.com/')
-    assert service.service_url == 'https://trailingSlash.com'
+    assert service.service_url == 'https://trailingSlash.com/'
     req = service.prepare_request('POST',
                                   url='/trailingSlashPath/',
                                   headers={'X-opt-out': True},
                                   data={'hello': 'world'})
-    assert req.get('url') == 'https://trailingSlash.com/trailingSlashPath'
+    assert req.get('url') == 'https://trailingSlash.com//trailingSlashPath'
 
     service = AnyServiceV1('2018-11-20', service_url='https://trailingSlash.com/', authenticator=NoAuthAuthenticator())
-    assert service.service_url == 'https://trailingSlash.com'
+    assert service.service_url == 'https://trailingSlash.com/'
     service.set_service_url('https://trailingSlash.com/')
-    assert service.service_url == 'https://trailingSlash.com'
+    assert service.service_url == 'https://trailingSlash.com/'
     req = service.prepare_request('POST',
                                   url='/',
                                   headers={'X-opt-out': True},
                                   data={'hello': 'world'})
-    assert req.get('url') == 'https://trailingSlash.com'
+    assert req.get('url') == 'https://trailingSlash.com/'
 
     service.set_service_url(None)
     assert service.service_url is None
 
     service = AnyServiceV1('2018-11-20', service_url='/', authenticator=NoAuthAuthenticator())
-    assert service.service_url == ''
+    assert service.service_url == '/'
     service.set_service_url('/')
-    assert service.service_url == ''
-    with pytest.raises(ValueError): # ValueError thrown because service_url is '' and falsey
-        req = service.prepare_request('POST',
-                                      url='/',
-                                      headers={'X-opt-out': True},
-                                      data={'hello': 'world'})
+    assert service.service_url == '/'
+    req = service.prepare_request('POST',
+                                  url='/',
+                                  headers={'X-opt-out': True},
+                                  data={'hello': 'world'})
+    assert req.get('url') == '/'
 
 def test_service_url_not_set():
     service = BaseService(service_url='', authenticator=NoAuthAuthenticator())


### PR DESCRIPTION
Stripping the service url is incompatible with the current python unit tests. We will need to make a generator change along with the stripping change if we want to make them compatible.