### PR TITLE
fix: Revert stripping request URL trailing slashes

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -272,7 +272,7 @@ class BaseService:
         # validate the service url is set
         if not self.service_url:
             raise ValueError('The service_url is required')
-        request['url'] = self.service_url + url.rstrip('/') # strip trailing slash
+        request['url'] = self.service_url + url
 
         headers = remove_null_values(headers) if headers else {}
         headers = cleanup_values(headers)

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -518,6 +518,7 @@ def test_json():
     req = service.prepare_request('POST', url='', headers={'X-opt-out': True}, data={'hello': 'world'})
     assert req.get('data') == "{\"hello\": \"world\"}"
 
+# For v2.x this test expects to see trailing slashes, this should be changed in v3.x
 def test_trailing_slash():
     service = AnyServiceV1('2018-11-20', service_url='https://trailingSlash.com/', authenticator=NoAuthAuthenticator())
     assert service.service_url == 'https://trailingSlash.com/'
@@ -527,7 +528,7 @@ def test_trailing_slash():
                                   url='/trailingSlashPath/',
                                   headers={'X-opt-out': True},
                                   data={'hello': 'world'})
-    assert req.get('url') == 'https://trailingSlash.com//trailingSlashPath'
+    assert req.get('url') == 'https://trailingSlash.com//trailingSlashPath/'
 
     service = AnyServiceV1('2018-11-20', service_url='https://trailingSlash.com/', authenticator=NoAuthAuthenticator())
     assert service.service_url == 'https://trailingSlash.com/'
@@ -537,7 +538,7 @@ def test_trailing_slash():
                                   url='/',
                                   headers={'X-opt-out': True},
                                   data={'hello': 'world'})
-    assert req.get('url') == 'https://trailingSlash.com/'
+    assert req.get('url') == 'https://trailingSlash.com//'
 
     service.set_service_url(None)
     assert service.service_url is None
@@ -550,7 +551,7 @@ def test_trailing_slash():
                                   url='/',
                                   headers={'X-opt-out': True},
                                   data={'hello': 'world'})
-    assert req.get('url') == '/'
+    assert req.get('url') == '//'
 
 def test_service_url_not_set():
     service = BaseService(service_url='', authenticator=NoAuthAuthenticator())


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1669

The fix added for stripping trailing slashes in both request URLs and service URLs causes an inconsistency in the python unit tests when checking the request and response URL.


Since changing the unit tests to to work with this core change would break compatibility for previous versions, this change is being moved to the v3.x version of the core where the new generator version with the unit test fix can specify the new core version.