### PR TITLE
fix: Combine multiple ending slashes to one

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -26,7 +26,13 @@ import requests
 from requests.structures import CaseInsensitiveDict
 from ibm_cloud_sdk_core.authenticators import Authenticator
 from .version import __version__
-from .utils import has_bad_first_or_last_char, remove_null_values, cleanup_values, read_external_sources
+from .utils import (
+    has_bad_first_or_last_char,
+    remove_null_values,
+    cleanup_values,
+    read_external_sources,
+    strip_extra_slashes
+)
 from .detailed_response import DetailedResponse
 from .api_exception import ApiException
 from .token_manager import TokenManager
@@ -234,7 +240,6 @@ class BaseService:
             logging.exception('Error in service call')
             raise
 
-
     def prepare_request(self,
                         method: str,
                         url: str,
@@ -272,7 +277,7 @@ class BaseService:
         # validate the service url is set
         if not self.service_url:
             raise ValueError('The service_url is required')
-        request['url'] = self.service_url + url
+        request['url'] = strip_extra_slashes(self.service_url + url)
 
         headers = remove_null_values(headers) if headers else {}
         headers = cleanup_values(headers)

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -68,6 +68,12 @@ def cleanup_value(value: any) -> any:
         return 'true' if value else 'false'
     return value
 
+def strip_extra_slashes(value: str) -> str:
+    """Combine multiple trailing slashes to a single slash"""
+    if value.endswith('//'):
+        return value.rstrip('/') + '/'
+    return value
+
 def datetime_to_string(val: datetime.datetime) -> str:
     """Convert a datetime object to string.
 


### PR DESCRIPTION
ref: https://github.ibm.com/arf/planning-sdk-squad/issues/1786

This fix combines the trailing slashes together to one. Since trailing slash and no trailing slash can mean different endpoints based on the server, we must repect which path is chosen.

Fixing the request URL like this will break compatibility with previous generator versions since their unit tests use the un-filtered url in the responses object.