### PR TITLE
feat(BaseService): support stream=True in BaseService.send()

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -211,6 +211,9 @@ class BaseService:
         if self.disable_ssl_verification:
             kwargs['verify'] = False
 
+        # Check to see if the caller specified the 'stream' argument.
+        stream_response = kwargs.get('stream') or False
+
         try:
             response = requests.request(**request, cookies=self.jar, **kwargs)
 
@@ -218,6 +221,8 @@ class BaseService:
                 if response.status_code == 204 or request['method'] == 'HEAD':
                     # There is no body content for a HEAD request or a 204 response
                     result = None
+                elif stream_response:
+                    result = response
                 elif not response.text:
                     result = None
                 else:


### PR DESCRIPTION
Fixes: arf/planning-sdk-squad/issues/901

This change allows generated operation code to pass 'stream=True' to
the BaseService.send() method, which will in turn pass it on to the
underlying requests.request() method.  The net result is that
the response body (even if it is a JSON object) will be "streamed",
which means it will be made available via the requests.Response object
rather than consumed and set on the DetailedResponse object.
To access the streamed response, simply retrieve the requests.Response
object by calling DetailedResponse.get_result(), then use the "iter_content"
method on the returned requests.Response instance.