### PR TITLE
chore: drop pandoc conversion of README in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,19 +30,6 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload -r pypi')
     sys.exit()
 
-# Convert README.md to README.rst for pypi
-try:
-    from pypandoc import convert_file
-
-    def read_md(f):
-        return convert_file(f, 'rst')
-except:
-    print('warning: pypandoc module not found, '
-          'could not convert Markdown to RST')
-
-    def read_md(f):
-        return open(f, 'rb').read().decode(encoding='utf-8')
-
 
 class PyTest(TestCommand):
     def finalize_options(self):
@@ -55,6 +42,8 @@ class PyTest(TestCommand):
         errcode = pytest.main(self.test_args)
         sys.exit(errcode)
 
+with open("README.md", "r") as fh:
+    readme = fh.read()
 
 setup(name='ibm-cloud-sdk-core',
       version=__version__,
@@ -65,7 +54,8 @@ setup(name='ibm-cloud-sdk-core',
       cmdclass={'test': PyTest},
       author='IBM',
       author_email='devexdev@us.ibm.com',
-      long_description=read_md('README.md'),
+      long_description=readme,
+      long_description_content_type='text/markdown',
       url='https://github.com/IBM/python-sdk-core',
       packages=find_packages(),
       include_package_data=True,


### PR DESCRIPTION
This PR eliminates the logic in `setup.py` that converted `README.md` to "restructured text" format.  This logic depended on `pandoc` and `pypandoc` but these packages were not identified as dependencies in the "requirements" files.  This could result in scary error messages for users.  And this seems completely unnecessary since PyPI handles markdown format just fine.