### PR TITLE
fix: restrict requests version to newer version to avoid vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.0,<3.0
+requests>=2.20,<3.0
 python_dateutil>=2.5.3
 PyJWT >=1.7.1


### PR DESCRIPTION
The `requests` library added dependencies that use LGPL in version 2.16. To avoid these we can restrict the library to versions before 2.16