### PR TITLE
fix: use options dict for jwt.decode verify flag

### DIFF
--- a/ibm_cloud_sdk_core/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/jwt_token_manager.py
@@ -68,7 +68,7 @@ class JWTTokenManager(TokenManager, ABC):
         self.access_token = token_response.get(self.token_name)
 
         # The time of expiration is found by decoding the JWT access token
-        decoded_response = jwt.decode(self.access_token, verify=False)
+        decoded_response = jwt.decode(self.access_token, options={"verify_signature": False})
         # exp is the time of expire and iat is the time of token retrieval
         exp = decoded_response.get('exp')
         iat = decoded_response.get('iat')


### PR DESCRIPTION
Closes  #88

The `verify` parameter for the `jwt.decode` function has been deprecated as of PyJWT v2.0.0. It has been moved into an `options` dictionary with key `verify_signature`. This PR updates the code to use the new dict.

Note that when I cloned the repo there were several failing tests unrelated to this code change (the same tests failed both before and after the code change).