### PR TITLE
chore: update PyJWT version to <2.0.0 and restrict other req versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,14 @@
 # test dependencies
-pytest>=2.8.2
-responses>=0.9.0
-pylint>=1.4.4
-tox>=2.9.1
-pytest-rerunfailures>=3.1
+pytest>=2.8.2,<7.0.0
+responses>=0.9.0,<1.0.0
+pylint>=1.4.4,<3.0.0
+tox>=2.9.1,<4.0.0
+pytest-rerunfailures>=3.1,<10.0.0
 
 # code coverage
-coverage<5
-codecov>=1.6.3
-pytest-cov>=2.2.1
+coverage<5,<6.0.0
+codecov>=1.6.3,<3.0.0
+pytest-cov>=2.2.1,<3.0.0
 
 # semantic
-bumpversion>=0.5.3
+bumpversion>=0.5.3,<1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.20,<3.0
-python_dateutil>=2.5.3
-PyJWT >=1.7.1
+python_dateutil>=2.5.3,<3.0.0
+PyJWT >=1.7.1,<2.0.0


### PR DESCRIPTION
PyJWT version >=2.0.0 had a recent breaking change, this restricts the version until we update our code to use the new change. This also adds a max version to the other requirements 