### PR TITLE
fix: bump minimum requirement versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
 # test dependencies
-pytest>=2.8.2,<7.0.0
+pytest>=3.10.1,<7.0.0
 responses>=0.9.0,<1.0.0
-pylint>=1.4.4,<3.0.0
+pylint>=2.0.0,<3.0.0
 tox>=2.9.1,<4.0.0
-pytest-rerunfailures>=3.1,<10.0.0
+pytest-rerunfailures>=5.0,<10.0.0
 
 # code coverage
 coverage<5,<6.0.0


### PR DESCRIPTION
Increase the minimum versions for some requirements and cause a minor version release for the requirements changes.