### PR TITLE
fix: update pyjwt parameters to satisfy 2.x changes

### DIFF
--- a/ibm_cloud_sdk_core/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/jwt_token_manager.py
@@ -68,7 +68,7 @@ class JWTTokenManager(TokenManager, ABC):
         self.access_token = token_response.get(self.token_name)
 
         # The time of expiration is found by decoding the JWT access token
-        decoded_response = jwt.decode(self.access_token, verify=False)
+        decoded_response = jwt.decode(self.access_token, algorithms=["RS256"], options={"verify_signature": False})
         # exp is the time of expire and iat is the time of token retrieval
         exp = decoded_response.get('exp')
         iat = decoded_response.get('iat')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.20,<3.0
 python_dateutil>=2.5.3,<3.0.0
-PyJWT >=1.7.1,<2.0.0
+PyJWT>=2.0.0a1,<3.0.0

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -111,7 +111,7 @@ def get_access_token() -> str:
         headers={
             'kid': '230498151c214b788dd97f22b85410a5'
         })
-    return access_token.decode('utf-8')
+    return access_token
 
 
 @responses.activate

--- a/test/test_cp4d_authenticator.py
+++ b/test/test_cp4d_authenticator.py
@@ -85,7 +85,7 @@ def test_get_token():
 
     access_token = jwt.encode(access_token_layout,
                               'secret', algorithm='HS256',
-                              headers={'kid': '230498151c214b788dd97f22b85410a5'}).decode('utf-8')
+                              headers={'kid': '230498151c214b788dd97f22b85410a5'})
     response = {
         "accessToken": access_token,
         "token_type": "Bearer",

--- a/test/test_cp4d_token_manager.py
+++ b/test/test_cp4d_token_manager.py
@@ -27,7 +27,7 @@ def test_request_token():
 
     access_token = jwt.encode(access_token_layout,
                               'secret', algorithm='HS256',
-                              headers={'kid': '230498151c214b788dd97f22b85410a5'}).decode('utf-8')
+                              headers={'kid': '230498151c214b788dd97f22b85410a5'})
     response = {
         "accessToken": access_token,
     }

--- a/test/test_iam_authenticator.py
+++ b/test/test_iam_authenticator.py
@@ -92,7 +92,6 @@ def test_get_token():
         headers={
             'kid': '230498151c214b788dd97f22b85410a5'
         })
-    access_token = access_token.decode('utf-8')
     response = {
         "access_token": access_token,
         "token_type": "Bearer",

--- a/test/test_iam_token_manager.py
+++ b/test/test_iam_token_manager.py
@@ -25,7 +25,7 @@ def get_access_token() -> str:
 
     access_token = jwt.encode(access_token_layout, 'secret', algorithm='HS256',
                               headers={'kid': '230498151c214b788dd97f22b85410a5'})
-    return access_token.decode('utf-8')
+    return access_token
 
 @responses.activate
 def test_request_token_auth_default():


### PR DESCRIPTION
This change includes updates to the jwt.decode call from by updating the verify options from https://github.com/IBM/python-sdk-core/pull/89 and specifying the algorithm in the decode to satisfy new changes in version 2.0.0 of pyjwt.