### PR TITLE
fix: include requirements.txt in MANIFEST.in for setup.py reference

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements.txt
+include requirements-dev.txt
+include LICENSE


### PR DESCRIPTION
requirements.txt needs to be included in the MANIFEST.in file to be included in setup.py