### PR TITLE
Add get_query_param utility method to support pagination

### DIFF
--- a/ibm_cloud_sdk_core/__init__.py
+++ b/ibm_cloud_sdk_core/__init__.py
@@ -29,6 +29,7 @@ functions:
     string_to_date: De-serializes a string to a date.
     convert_model: Convert a model object into an equivalent dict.
     convert_list: Convert a list of strings into comma-separated string.
+    get_query_param: Return a query parameter value from a URL
     read_external_sources: Get config object from external sources.
     get_authenticator_from_environment: Get authenticator from external sources.
 """
@@ -42,4 +43,5 @@ from .api_exception import ApiException
 from .utils import datetime_to_string, string_to_datetime, read_external_sources
 from .utils import date_to_string, string_to_date
 from .utils import convert_model, convert_list
+from .utils import get_query_param
 from .get_authenticator import get_authenticator_from_environment

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -19,6 +19,7 @@ import json as json_import
 from os import getenv, environ, getcwd
 from os.path import isfile, join, expanduser
 from typing import List, Union
+from urllib.parse import urlparse, parse_qs
 
 import dateutil.parser as date_parser
 
@@ -141,6 +142,29 @@ def string_to_date(string: str) -> datetime.date:
     """
     return date_parser.parse(string).date()
 
+def get_query_param(url_str: str, param: str) -> str:
+    """Return a query parameter value from url_str
+
+    Args:
+        url_str: the URL from which to extract the query
+            parameter value
+        param: the name of the query parameter whose value
+            should be returned
+
+    Returns:
+        the value of the `param` query parameter as a string
+
+    Raises:
+        ValueError: if errors are encountered parsing `url_str`
+    """
+    if not url_str:
+        return None
+    url = urlparse(url_str)
+    if not url.query:
+        return None
+    query = parse_qs(url.query, strict_parsing=True)
+    values = query.get(param)
+    return values[0] if values else None
 
 def convert_model(val: any) -> dict:
     """Convert a model object into an equivalent dict.


### PR DESCRIPTION
This PR adds a small utility method to extract the value of a query parameter from a URL string. This will be used in the pagination support for Python.