### PR TITLE
feat: add datetime to string utils for lists

### DIFF
--- a/ibm_cloud_sdk_core/__init__.py
+++ b/ibm_cloud_sdk_core/__init__.py
@@ -25,6 +25,8 @@ classes:
 functions:
     datetime_to_string: Serializes a datetime to a string.
     string_to_datetime: De-serializes a string to a datetime.
+    datetime_to_string_list: Serializes a list of datetimes to a list of strings.
+    string_to_datetime_list: De-serializes a list of strings to a list of datetimes.
     date_to_string: Serializes a date to a string.
     string_to_date: De-serializes a string to a date.
     convert_model: Convert a model object into an equivalent dict.
@@ -41,6 +43,7 @@ from .jwt_token_manager import JWTTokenManager
 from .cp4d_token_manager import CP4DTokenManager
 from .api_exception import ApiException
 from .utils import datetime_to_string, string_to_datetime, read_external_sources
+from .utils import datetime_to_string_list, string_to_datetime_list
 from .utils import date_to_string, string_to_date
 from .utils import convert_model, convert_list
 from .utils import get_query_param

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -117,6 +117,40 @@ def string_to_datetime(string: str) -> datetime.datetime:
     return val.replace(tzinfo=datetime.timezone.utc)
 
 
+def string_to_datetime_list(string_list: List[str]) -> List[datetime.datetime]:
+    """De-serializes each string in a list to a datetime.
+
+    Args:
+        string_list: list of strings containing datetime in iso8601 format.
+
+    Returns:
+        the de-serialized list of strings as a list of datetime objects.
+    """
+    if not isinstance(string_list, list):
+        raise ValueError("Invalid argument type: " + str(type(string_list))
+            + ". Argument string_list must be of type List[str]")
+    datetime_list = []
+    for string_val in string_list:
+        datetime_list.append(string_to_datetime(string_val))
+    return datetime_list
+
+def datetime_to_string_list(datetime_list: List[datetime.datetime]) -> List[str]:
+    """Convert a list of datetime objects to a list of strings.
+
+    Args:
+        datetime_list: The list of datetime objects.
+
+    Returns:
+        list of datetimes serialized as strings in iso8601 format.
+    """
+    if not isinstance(datetime_list, list):
+        raise ValueError("Invalid argument type: " + str(type(datetime_list))
+            + ". Argument datetime_list must be of type List[datetime.datetime]")
+    string_list = []
+    for datetime_val in datetime_list:
+        string_list.append(datetime_to_string(datetime_val))
+    return string_list
+
 def date_to_string(val: datetime.date) -> str:
     """Convert a date object to string.
 


### PR DESCRIPTION
Adds two util functions to convert a list of DateTime to a list of str and vice versa. This is used for a new fix in the Python generator for formatting mock data values for generated unit tests.