### PR TITLE
fix: remove http retry support

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -109,14 +109,12 @@ class BaseService:
             allowed_methods=['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE', 'POST']
         )
         self.http_adapter = HTTPAdapter(max_retries=self.retry_config)
-        self.http_client.mount('http://', self.http_adapter)
         self.http_client.mount('https://', self.http_adapter)
 
     def disable_retries(self):
         """Remove retry config from http_adapter"""
         self.retry_config = None
         self.http_adapter = HTTPAdapter()
-        self.http_client.mount('http://', self.http_adapter)
         self.http_client.mount('https://', self.http_adapter)
 
     @staticmethod


### PR DESCRIPTION
Recent codescans have flagged these two lines as vulnerabilities, given that `https://` should be used.  This PR removes these vulnerabilities, so that only retries with `https://` will be supported.

Ultimately, all of our users should be using `https://` in their service URLs.  Any objections to removing `http://` retry support?  CC: @padamstx @hudlow @rmkeezer 