### PR TITLE
feat: support api key use case for CP4D authenticator

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-03-18T14:18:04Z",
+  "generated_at": "2021-05-04T15:09:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -173,8 +173,16 @@
         "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 113,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5eb942810a75ebc850972a89285d570d484c89c4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 307,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -185,6 +193,14 @@
         "is_verified": false,
         "line_number": 88,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "5eb942810a75ebc850972a89285d570d484c89c4",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 99,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -287,7 +303,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.29.dss",
+  "version": "0.13.1+ibm.34.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/Authentication.md
+++ b/Authentication.md
@@ -140,7 +140,7 @@ service = ExampleService(authenticator=authenticator)
 ```
 
 ##  Cloud Pak for Data
-The `CloudPakForDataAuthenticator` will accept user-supplied username and password values, and will
+The `CloudPakForDataAuthenticator` will accept a user-supplied username and either a password or an apikey value, and will
 perform the necessary interactions with the Cloud Pak for Data token service to obtain a suitable
 bearer token.  The authenticator will also obtain a new bearer token when the current token expires.
 The bearer token is then added to each outbound request in the `Authorization` header in the
@@ -150,8 +150,9 @@ form:
 ```
 ### Properties
 - username: (required) the username used to obtain a bearer token.
-- password: (required) the password used to obtain a bearer token.
+- password: (required if apikey is not specified) the password used to obtain a bearer token.
 - url: (required) The URL representing the Cloud Pak for Data token service endpoint.
+- apikey: (required if password is not specified) the apikey used to obtain a bearer token.
 - disableSSLVerification: (optional) A flag that indicates whether verificaton of the server's SSL
 certificate should be disabled or not. The default value is `false`.
 - headers: (optional) A set of key/value pairs that will be sent as HTTP headers in requests
@@ -160,11 +161,20 @@ made to the IAM token service.
 ```python
 from ibm_cloud_sdk_core.authenticators import CloudPakForDataAuthenticator
 
+# Username / password authentication
 authenticator = CloudPakForDataAuthenticator(
-                 'my_username',
-                 'my_password',
-                 'https://my-cp4d-url',
+                 username='my_username',
+                 password='my_password',
+                 url='https://my-cp4d-url',
                  disable_ssl_verification=True)
+
+# Username / apikey authentication
+authenticator = CloudPakForDataAuthenticator(
+                 username='my_username',
+                 apikey='my_apikey',
+                 url='https://my-cp4d-url',
+                 disable_ssl_verification=True)
+
 service = ExampleService(authenticator=authenticator)
 
 service.get_authenticator().set_headers({'dummy': 'headers'})
@@ -172,9 +182,16 @@ service.get_authenticator().set_headers({'dummy': 'headers'})
 ### Configuration example
 External configuration:
 ```
+# Username / password authentication
 export EXAMPLE_SERVICE_AUTH_TYPE=cp4d
 export EXAMPLE_SERVICE_USERNAME=myuser
 export EXAMPLE_SERVICE_PASSWORD=mypassword
+export EXAMPLE_SERVICE_URL=https://mycp4dhost.com/
+
+# Username / apikey authentication
+export EXAMPLE_SERVICE_AUTH_TYPE=cp4d
+export EXAMPLE_SERVICE_USERNAME=myuser
+export EXAMPLE_SERVICE_APIKEY=myapikey
 export EXAMPLE_SERVICE_URL=https://mycp4dhost.com/
 ```
 Application code:

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -54,6 +54,7 @@ def __construct_authenticator(config: dict) -> Authenticator:
             username=config.get('USERNAME'),
             password=config.get('PASSWORD'),
             url=config.get('AUTH_URL'),
+            apikey=config.get('APIKEY'),
             disable_ssl_verification=config.get('AUTH_DISABLE_SSL'))
     elif auth_type == 'iam' and config.get('APIKEY'):
         authenticator = IAMAuthenticator(

--- a/resources/ibm-credentials-cp4dtest.env.example
+++ b/resources/ibm-credentials-cp4dtest.env.example
@@ -1,0 +1,11 @@
+CP4D_PASSWORD_TEST_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+CP4D_PASSWORD_TEST_AUTH_TYPE=cp4d
+CP4D_PASSWORD_TEST_USERNAME=<username>
+CP4D_PASSWORD_TEST_PASSWORD=<password>
+CP4D_PASSWORD_TEST_AUTH_DISABLE_SSL=true
+
+CP4D_APIKEY_TEST_AUTH_URL=<url>   e.g. https://cpd350-cpd-cpd350.apps.wml-kf-cluster.os.fyre.ibm.com/icp4d-api
+CP4D_APIKEY_TEST_AUTH_TYPE=cp4d
+CP4D_APIKEY_TEST_USERNAME=<username>
+CP4D_APIKEY_TEST_APIKEY=<apikey>
+CP4D_APIKEY_TEST_AUTH_DISABLE_SSL=true  

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -293,7 +293,7 @@ def test_for_cp4d():
     assert service.authenticator.token_manager is not None
     assert service.authenticator.token_manager.username == 'my_username'
     assert service.authenticator.token_manager.password == 'my_password'
-    assert service.authenticator.token_manager.url == 'my_url/v1/preauth/validateAuth'
+    assert service.authenticator.token_manager.url == 'my_url/v1/authorize'
     assert isinstance(service.authenticator.token_manager, CP4DTokenManager)
 
 
@@ -648,10 +648,10 @@ def test_files_dict():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
 
     form_data = {}
-    file = open(
+    with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r')
-    form_data['file1'] = (None, file, 'application/octet-stream')
+            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r') as file:
+        form_data['file1'] = (None, file, 'application/octet-stream')
     form_data['string1'] = (None, 'hello', 'text/plain')
     request = service.prepare_request('GET', url='', headers={'X-opt-out': True}, files=form_data)
     files = request['files']
@@ -667,10 +667,10 @@ def test_files_list():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
 
     form_data = []
-    file = open(
+    with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r')
-    form_data.append(('file1', (None, file, 'application/octet-stream')))
+            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r') as file:
+        form_data.append(('file1', (None, file, 'application/octet-stream')))
     form_data.append(('string1', (None, 'hello', 'text/plain')))
     request = service.prepare_request('GET', url='', headers={'X-opt-out': True}, files=form_data)
     files = request['files']
@@ -686,18 +686,18 @@ def test_files_duplicate_parts():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
 
     form_data = []
-    file = open(
+    with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r')
-    form_data.append(('creds_file', (None, file, 'application/octet-stream')))
-    file = open(
+            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r') as file:
+        form_data.append(('creds_file', (None, file, 'application/octet-stream')))
+    with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-basic.env'), 'r')
-    form_data.append(('creds_file', (None, file, 'application/octet-stream')))
-    file = open(
+            os.path.dirname(__file__), '../resources/ibm-credentials-basic.env'), 'r') as file:
+        form_data.append(('creds_file', (None, file, 'application/octet-stream')))
+    with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-bearer.env'), 'r')
-    form_data.append(('creds_file', (None, file, 'application/octet-stream')))
+            os.path.dirname(__file__), '../resources/ibm-credentials-bearer.env'), 'r') as file:
+        form_data.append(('creds_file', (None, file, 'application/octet-stream')))
     request = service.prepare_request('GET', url='', headers={'X-opt-out': True}, files=form_data)
     files = request['files']
     assert isinstance(files, list)

--- a/test/test_cp4d_token_manager.py
+++ b/test/test_cp4d_token_manager.py
@@ -29,20 +29,26 @@ def test_request_token():
                               'secret', algorithm='HS256',
                               headers={'kid': '230498151c214b788dd97f22b85410a5'})
     response = {
-        "accessToken": access_token,
+        "token": access_token,
     }
-    responses.add(responses.GET, url + '/v1/preauth/validateAuth', body=json.dumps(response), status=200)
+    responses.add(responses.POST, url + '/v1/authorize', body=json.dumps(response), status=200)
 
     token_manager = CP4DTokenManager("username", "password", url)
     token_manager.set_disable_ssl_verification(True)
     token = token_manager.get_token()
 
     assert len(responses.calls) == 1
-    assert responses.calls[0].request.url == url + '/v1/preauth/validateAuth'
+    assert responses.calls[0].request.url == url + '/v1/authorize'
     assert token == access_token
 
-    token_manager = CP4DTokenManager("username", "password", url + '/v1/preauth/validateAuth')
+    token_manager = CP4DTokenManager("username", "password", url + '/v1/authorize')
     token = token_manager.get_token()
     assert len(responses.calls) == 2
-    assert responses.calls[1].request.url == url + '/v1/preauth/validateAuth'
+    assert responses.calls[1].request.url == url + '/v1/authorize'
+    assert token == access_token
+
+    token_manager = CP4DTokenManager(username="username", apikey="fake_api_key", url=url + '/v1/authorize')
+    token = token_manager.get_token()
+    assert len(responses.calls) == 3
+    assert responses.calls[2].request.url == url + '/v1/authorize'
     assert token == access_token

--- a/test_integration/test_cp4d_authenticator_integration.py
+++ b/test_integration/test_cp4d_authenticator_integration.py
@@ -1,0 +1,43 @@
+# pylint: disable=missing-docstring
+import os
+
+from ibm_cloud_sdk_core import get_authenticator_from_environment
+
+# Note: Only the unit tests are run by default.
+#
+# In order to test with a live CP4D server, rename "ibm-credentials-cp4dtest.env.example" to
+# "ibm-credentials-cp4dtest.env" in the resources folder and populate the fields.
+# Then run this command:
+# pytest test_integration
+
+IBM_CREDENTIALS_FILE = '../resources/ibm-credentials-cp4dtest.env'
+
+def test_cp4d_authenticator_password():
+    file_path = os.path.join(
+        os.path.dirname(__file__), IBM_CREDENTIALS_FILE)
+    os.environ['IBM_CREDENTIALS_FILE'] = file_path
+
+    authenticator = get_authenticator_from_environment('cp4d_password_test')
+    assert authenticator is not None
+    assert authenticator.token_manager.password is not None
+    assert authenticator.token_manager.apikey is None
+
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] is not None
+    assert 'Bearer' in request['headers']['Authorization']
+
+def test_cp4d_authenticator_apikey():
+    file_path = os.path.join(
+        os.path.dirname(__file__), IBM_CREDENTIALS_FILE)
+    os.environ['IBM_CREDENTIALS_FILE'] = file_path
+
+    authenticator = get_authenticator_from_environment('cp4d_apikey_test')
+    assert authenticator is not None
+    assert authenticator.token_manager.password is None
+    assert authenticator.token_manager.apikey is not None
+
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] is not None
+    assert 'Bearer' in request['headers']['Authorization']


### PR DESCRIPTION
Adds support for API key and password support in the CP4D authenticator and updated authorization URL. 
