### PR TITLE
fix: remove reserved keywords from kwargs before passing it to requests

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,8 @@ disable=
     duplicate-code,
     missing-module-docstring,
     too-many-arguments,
-    unnecessary-pass
+    unnecessary-pass,
+    no-member,
 
 [TYPECHECK]
 ignored-classes= responses

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -277,6 +277,11 @@ class BaseService:
         # Check to see if the caller specified the 'stream' argument.
         stream_response = kwargs.get('stream') or False
 
+        # Remove the keys we set manually, don't let the user to overwrite these.
+        reserved_keys = ['method', 'url', 'headers', 'params', 'cookies']
+        for key in reserved_keys:
+            kwargs.pop(key, None)
+
         try:
             response = self.http_client.request(**request,
                                                 cookies=self.jar,

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -280,8 +280,9 @@ class BaseService:
         # Remove the keys we set manually, don't let the user to overwrite these.
         reserved_keys = ['method', 'url', 'headers', 'params', 'cookies']
         for key in reserved_keys:
-            kwargs.pop(key, None)
-
+            if key in kwargs:
+                del kwargs[key]
+                logging.warning('"%s" has been removed from the request', key)
         try:
             response = self.http_client.request(**request,
                                                 cookies=self.jar,

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -685,6 +685,30 @@ def test_user_agent_header():
     assert response.get_result().request.headers.__getitem__(
         'user-agent') == user_agent_header['User-Agent']
 
+@responses.activate
+def test_reserved_keys(caplog):
+    service = AnyServiceV1('2021-07-02', authenticator=NoAuthAuthenticator())
+    responses.add(
+        responses.GET,
+        'https://gateway.watsonplatform.net/test/api',
+        status=200,
+        body='some text')
+    prepped = service.prepare_request('GET', url='', headers={'key': 'OK'})
+    response = service.send(
+        prepped,
+        headers={'key': 'bad'},
+        method='POST',
+        url='localhost',
+        cookies=None,
+        hooks={'response': []})
+    assert response.get_result().request.headers.__getitem__('key') == 'OK'
+    assert response.get_result().request.url == 'https://gateway.watsonplatform.net/test/api'
+    assert response.get_result().request.method == 'GET'
+    assert response.get_result().request.hooks == {'response': []}
+    assert caplog.record_tuples[0][2] == '"method" has been removed from the request'
+    assert caplog.record_tuples[1][2] == '"url" has been removed from the request'
+    assert caplog.record_tuples[2][2] == '"headers" has been removed from the request'
+    assert caplog.record_tuples[3][2] == '"cookies" has been removed from the request'
 
 def test_files_dict():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())


### PR DESCRIPTION
This PR introduces a minor change/improvement: removal of some reserved keys from the `kwargs` of the base services' send function.