### PR TITLE
refactor: use shared code for IAM based authenticators

### DIFF
--- a/ibm_cloud_sdk_core/__init__.py
+++ b/ibm_cloud_sdk_core/__init__.py
@@ -38,9 +38,9 @@ functions:
 
 from .base_service import BaseService
 from .detailed_response import DetailedResponse
-from .iam_token_manager import IAMTokenManager
-from .jwt_token_manager import JWTTokenManager
-from .cp4d_token_manager import CP4DTokenManager
+from .token_managers.iam_token_manager import IAMTokenManager
+from .token_managers.jwt_token_manager import JWTTokenManager
+from .token_managers.cp4d_token_manager import CP4DTokenManager
 from .api_exception import ApiException
 from .utils import datetime_to_string, string_to_datetime, read_external_sources
 from .utils import datetime_to_string_list, string_to_datetime_list

--- a/ibm_cloud_sdk_core/api_exception.py
+++ b/ibm_cloud_sdk_core/api_exception.py
@@ -13,8 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+
 from http import HTTPStatus
+from typing import Optional
+
 from requests import Response
 
 

--- a/ibm_cloud_sdk_core/authenticators/authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/authenticator.py
@@ -16,6 +16,7 @@
 
 from abc import ABC, abstractmethod
 
+
 class Authenticator(ABC):
     """This interface defines the common methods and constants associated with an Authenticator implementation."""
     @abstractmethod

--- a/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
@@ -18,6 +18,7 @@ from requests import Request
 
 from .authenticator import Authenticator
 
+
 class BearerTokenAuthenticator(Authenticator):
     """The BearerTokenAuthenticator will add a user-supplied bearer token
     to requests.

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -19,7 +19,7 @@ from typing import Dict, Optional
 from requests import Request
 
 from .authenticator import Authenticator
-from ..cp4d_token_manager import CP4DTokenManager
+from ..token_managers.cp4d_token_manager import CP4DTokenManager
 from ..utils import has_bad_first_or_last_char
 
 

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -16,13 +16,11 @@
 
 from typing import Dict, Optional
 
-from requests import Request
-
-from .authenticator import Authenticator
+from .iam_request_based_authenticator import IAMRequestBasedAuthenticator
 from ..iam_token_manager import IAMTokenManager
 from ..utils import has_bad_first_or_last_char
 
-class IAMAuthenticator(Authenticator):
+class IAMAuthenticator(IAMRequestBasedAuthenticator):
     """The IAMAuthenticator utilizes an apikey, or client_id and client_secret pair to
     obtain a suitable bearer token, and adds it to requests.
 
@@ -81,6 +79,8 @@ class IAMAuthenticator(Authenticator):
         Raises:
             ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
         """
+        super().validate()
+
         if self.token_manager.apikey is None:
             raise ValueError('The apikey shouldn\'t be None.')
 
@@ -88,74 +88,3 @@ class IAMAuthenticator(Authenticator):
             raise ValueError(
                 'The apikey shouldn\'t start or end with curly brackets or quotes. '
                 'Please remove any surrounding {, }, or \" characters.')
-
-        if (self.token_manager.client_id and
-                not self.token_manager.client_secret) or (
-                    not self.token_manager.client_id and
-                    self.token_manager.client_secret):
-            raise ValueError(
-                'Both client_id and client_secret should be initialized.')
-
-    def authenticate(self, req: Request) -> None:
-        """Adds IAM authentication information to the request.
-
-        The IAM bearer token will be added to the request's headers in the form:
-
-            Authorization: Bearer <bearer-token>
-
-        Args:
-            req: The request to add IAM authentication information too. Must contain a key to a dictionary
-            called headers.
-        """
-        headers = req.get('headers')
-        bearer_token = self.token_manager.get_token()
-        headers['Authorization'] = 'Bearer {0}'.format(bearer_token)
-
-    def set_client_id_and_secret(self, client_id: str, client_secret: str) -> None:
-        """Set the client_id and client_secret pair the token manager will use for IAM token requests.
-
-        Args:
-            client_id: The client id to be used in basic auth.
-            client_secret: The client secret to be used in basic auth.
-
-        Raises:
-            ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
-        """
-        self.token_manager.set_client_id_and_secret(client_id, client_secret)
-        self.validate()
-
-    def set_disable_ssl_verification(self, status: bool = False) -> None:
-        """Set the flag that indicates whether verification of the server's SSL certificate should be
-        disabled or not. Defaults to False.
-
-        Keyword Arguments:
-            status: Headers to be sent with every IAM token request. Defaults to None.
-        """
-        self.token_manager.set_disable_ssl_verification(status)
-
-    def set_headers(self, headers: Dict[str, str]) -> None:
-        """Headers to be sent with every IAM token request.
-
-        Args:
-            headers: Headers to be sent with every IAM token request.
-        """
-        self.token_manager.set_headers(headers)
-
-    def set_proxies(self, proxies: Dict[str, str]) -> None:
-        """Sets the proxies the token manager will use to communicate with IAM on behalf of the host.
-
-        Args:
-            proxies: Dictionary for mapping request protocol to proxy URL.
-            proxies.http (optional): The proxy endpoint to use for HTTP requests.
-            proxies.https (optional): The proxy endpoint to use for HTTPS requests.
-        """
-        self.token_manager.set_proxies(proxies)
-
-    def set_scope(self, value: str) -> None:
-        """Sets the "scope" parameter to use when fetching the bearer token from the IAM token server.
-        This can be used to obtain an access token with a specific scope.
-
-        Args:
-            value: A space seperated string that makes up the scope parameter.
-        """
-        self.token_manager.set_scope(value)

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -20,6 +20,7 @@ from .iam_request_based_authenticator import IAMRequestBasedAuthenticator
 from ..token_managers.iam_token_manager import IAMTokenManager
 from ..utils import has_bad_first_or_last_char
 
+
 class IAMAuthenticator(IAMRequestBasedAuthenticator):
     """The IAMAuthenticator utilizes an apikey, or client_id and client_secret pair to
     obtain a suitable bearer token, and adds it to requests.

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -17,7 +17,7 @@
 from typing import Dict, Optional
 
 from .iam_request_based_authenticator import IAMRequestBasedAuthenticator
-from ..iam_token_manager import IAMTokenManager
+from ..token_managers.iam_token_manager import IAMTokenManager
 from ..utils import has_bad_first_or_last_char
 
 class IAMAuthenticator(IAMRequestBasedAuthenticator):

--- a/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
@@ -31,7 +31,6 @@ class IAMRequestBasedAuthenticator(Authenticator):
     Attributes:
         token_manager (TokenManager): Retrives and manages IAM tokens from the endpoint specified by the url.
     """
-    authentication_type = 'iam'
 
     def validate(self) -> None:
         """Validates the client_id, and client_secret for IAM token requests.

--- a/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
@@ -20,6 +20,7 @@ from requests import Request
 
 from .authenticator import Authenticator
 
+
 class IAMRequestBasedAuthenticator(Authenticator):
     """The IAMRequestBasedAuthenticator class contains code that is common to all authenticators
     that need to interact with the IAM tokens service to obtain an access token.

--- a/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
@@ -1,0 +1,113 @@
+# coding: utf-8
+
+# Copyright 2019 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+from requests import Request
+
+from .authenticator import Authenticator
+
+class IAMRequestBasedAuthenticator(Authenticator):
+    """The IAMRequestBasedAuthenticator class contains code that is common to all authenticators
+    that need to interact with the IAM tokens service to obtain an access token.
+
+    The bearer token will be sent as an Authorization header in the form:
+
+        Authorization: Bearer <bearer-token>
+
+    Attributes:
+        token_manager (TokenManager): Retrives and manages IAM tokens from the endpoint specified by the url.
+    """
+    authentication_type = 'iam'
+
+    def validate(self) -> None:
+        """Validates the client_id, and client_secret for IAM token requests.
+
+        Ensure both the client_id and client_secret are set if either of them are defined.
+
+        Raises:
+            ValueError: The client_id, and/or client_secret are not valid for IAM token requests.
+        """
+        if (self.token_manager.client_id and
+                not self.token_manager.client_secret) or (
+                    not self.token_manager.client_id and
+                    self.token_manager.client_secret):
+            raise ValueError(
+                'Both client_id and client_secret should be initialized.')
+
+    def authenticate(self, req: Request) -> None:
+        """Adds IAM authentication information to the request.
+
+        The IAM bearer token will be added to the request's headers in the form:
+
+            Authorization: Bearer <bearer-token>
+
+        Args:
+            req: The request to add IAM authentication information too. Must contain a key to a dictionary
+            called headers.
+        """
+        headers = req.get('headers')
+        bearer_token = self.token_manager.get_token()
+        headers['Authorization'] = 'Bearer {0}'.format(bearer_token)
+
+    def set_client_id_and_secret(self, client_id: str, client_secret: str) -> None:
+        """Set the client_id and client_secret pair the token manager will use for IAM token requests.
+
+        Args:
+            client_id: The client id to be used in basic auth.
+            client_secret: The client secret to be used in basic auth.
+
+        Raises:
+            ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
+        """
+        self.token_manager.set_client_id_and_secret(client_id, client_secret)
+        self.validate()
+
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
+        """Set the flag that indicates whether verification of the server's SSL certificate should be
+        disabled or not. Defaults to False.
+
+        Keyword Arguments:
+            status: Headers to be sent with every IAM token request. Defaults to None.
+        """
+        self.token_manager.set_disable_ssl_verification(status)
+
+    def set_headers(self, headers: Dict[str, str]) -> None:
+        """Headers to be sent with every IAM token request.
+
+        Args:
+            headers: Headers to be sent with every IAM token request.
+        """
+        self.token_manager.set_headers(headers)
+
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
+        """Sets the proxies the token manager will use to communicate with IAM on behalf of the host.
+
+        Args:
+            proxies: Dictionary for mapping request protocol to proxy URL.
+            proxies.http (optional): The proxy endpoint to use for HTTP requests.
+            proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+        """
+        self.token_manager.set_proxies(proxies)
+
+    def set_scope(self, value: str) -> None:
+        """Sets the "scope" parameter to use when fetching the bearer token from the IAM token server.
+        This can be used to obtain an access token with a specific scope.
+
+        Args:
+            value: A space seperated string that makes up the scope parameter.
+        """
+        self.token_manager.set_scope(value)

--- a/ibm_cloud_sdk_core/authenticators/no_auth_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/no_auth_authenticator.py
@@ -16,6 +16,7 @@
 
 from .authenticator import Authenticator
 
+
 class NoAuthAuthenticator(Authenticator):
     """Performs no authentication."""
     authentication_type = 'noAuth'

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -14,26 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-from http.cookiejar import CookieJar
+import gzip
 import json as json_import
-from os.path import basename
+import logging
 import platform
 import sys
-import gzip
+from http.cookiejar import CookieJar
+from os.path import basename
 from typing import Dict, List, Optional, Tuple, Union
+from urllib3.util.retry import Retry
 
 import requests
 from requests.adapters import HTTPAdapter
 from requests.structures import CaseInsensitiveDict
-from urllib3.util.retry import Retry
+
 from ibm_cloud_sdk_core.authenticators import Authenticator
-from .version import __version__
+from .api_exception import ApiException
+from .detailed_response import DetailedResponse
+from .token_managers.token_manager import TokenManager
 from .utils import (has_bad_first_or_last_char, remove_null_values,
                     cleanup_values, read_external_sources, strip_extra_slashes)
-from .detailed_response import DetailedResponse
-from .api_exception import ApiException
-from .token_managers.token_manager import TokenManager
+from .version import __version__
 
 # Uncomment this to enable http debugging
 # import http.client as http_client

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -33,7 +33,7 @@ from .utils import (has_bad_first_or_last_char, remove_null_values,
                     cleanup_values, read_external_sources, strip_extra_slashes)
 from .detailed_response import DetailedResponse
 from .api_exception import ApiException
-from .token_manager import TokenManager
+from .token_managers.token_manager import TokenManager
 
 # Uncomment this to enable http debugging
 # import http.client as http_client

--- a/ibm_cloud_sdk_core/detailed_response.py
+++ b/ibm_cloud_sdk_core/detailed_response.py
@@ -14,10 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from typing import Dict, Optional
 
-import json
 import requests
+
 
 class DetailedResponse:
     """Custom class for detailed response returned from APIs.

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -18,6 +18,7 @@ from .authenticators import (Authenticator, BasicAuthenticator, BearerTokenAuthe
                              CloudPakForDataAuthenticator, IAMAuthenticator, NoAuthAuthenticator)
 from .utils import read_external_sources
 
+
 def get_authenticator_from_environment(service_name: str) -> Authenticator:
     """Look for external configuration of authenticator.
 
@@ -37,6 +38,7 @@ def get_authenticator_from_environment(service_name: str) -> Authenticator:
     if config:
         authenticator = __construct_authenticator(config)
     return authenticator
+
 
 def __construct_authenticator(config: dict) -> Authenticator:
     auth_type = config.get('AUTH_TYPE').lower() if config.get('AUTH_TYPE') else 'iam'

--- a/ibm_cloud_sdk_core/iam_request_based_token_manager.py
+++ b/ibm_cloud_sdk_core/iam_request_based_token_manager.py
@@ -1,0 +1,168 @@
+# coding: utf-8
+
+# Copyright 2019 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Optional
+
+from .jwt_token_manager import JWTTokenManager
+
+class IAMRequestBasedTokenManager(JWTTokenManager):
+    """The IamRequestBasedTokenManager class contains code relevant to any token manager that
+    interacts with the IAM service to manage a token. It stores information relevant to all
+    IAM requests, such as the client ID and secret, and performs the token request with a set
+    of request options common to any IAM token management scheme.
+
+    If the current stored bearer token has expired a new bearer token will be retrieved.
+
+    Attributes:
+        request_payload(dict): the data that will be sent in the IAM OAuth token request
+        url (str): The IAM endpoint to token requests.
+        client_id (str): The client_id and client_secret fields are used to form
+            a "basic auth" Authorization header for interactions with the IAM token server.
+        client_secret (str): The client_id and client_secret fields are used to form
+            a "basic auth" Authorization header for interactions with the IAM token server.
+        headers (dict): Default headers to be sent with every IAM token request.
+        proxies (dict): Proxies to use for communicating with IAM.
+        proxies.http (str): The proxy endpoint to use for HTTP requests.
+        proxies.https (str): The proxy endpoint to use for HTTPS requests.
+        http_config (dict): A dictionary containing values that control the timeout, proxies, and etc of HTTP requests.
+        scope (str): The "scope" to use when fetching the bearer token from the IAM token server.
+        This can be used to obtain an access token with a specific scope.
+
+    Keyword Args:
+        url: The IAM endpoint to token requests. Defaults to None.
+        client_id: The client_id and client_secret fields are used to form
+            a "basic auth" Authorization header for interactions with the IAM token server.
+            Defaults to None.
+        client_secret: The client_id and client_secret fields are used to form
+            a "basic auth" Authorization header for interactions with the IAM token server.
+            Defaults to None.
+        disable_ssl_verification: A flag that indicates whether verification of
+            the server's SSL certificate should be disabled or not. Defaults to False.
+        headers: Default headers to be sent with every IAM token request. Defaults to None.
+        proxies: Proxies to use for communicating with IAM. Defaults to None.
+        proxies.http: The proxy endpoint to use for HTTP requests.
+        proxies.https: The proxy endpoint to use for HTTPS requests.
+        scope: The "scope" to use when fetching the bearer token from the IAM token server.
+        This can be used to obtain an access token with a specific scope.
+    """
+    DEFAULT_IAM_URL = 'https://iam.cloud.ibm.com'
+    OPERATION_PATH = "/identity/token"
+
+    request_payload = {}
+
+    def __init__(self,
+                 url: Optional[str] = None,
+                 client_id: Optional[str] = None,
+                 client_secret: Optional[str] = None,
+                 disable_ssl_verification: bool = False,
+                 headers: Optional[Dict[str, str]] = None,
+                 proxies: Optional[Dict[str, str]] = None,
+                 scope: Optional[str] = None) -> None:
+        if not url:
+            url = self.DEFAULT_IAM_URL
+        if url.endswith(self.OPERATION_PATH):
+            url = url[:-len(self.OPERATION_PATH)]
+        self.url = url
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.headers = headers
+        self.refresh_token = None
+        self.proxies = proxies
+        self.scope = scope
+        super().__init__(
+            self.url, disable_ssl_verification=disable_ssl_verification, token_name='access_token')
+
+    def request_token(self) -> dict:
+        """Request an IAM OAuth token given an API Key.
+
+        If client_id and client_secret are specified use their values as a user and pass auth set
+        according to WHATWG url spec.
+
+        Returns:
+             A dictionary containing the bearer token to be subsequently used service requests.
+        """
+        headers = {
+            'Content-type': 'applicaton/x-www-form-urlencoded',
+            'Accept': 'application/json'
+        }
+        if self.headers is not None and isinstance(self.headers, dict):
+            headers.update(self.headers)
+
+        data = dict(self.request_payload)
+
+        if self.scope is not None and self.scope:
+            data['scope'] = self.scope
+
+        auth_tuple = None
+        # If both the client_id and secret were specified by the user, then use them
+        if self.client_id and self.client_secret:
+            auth_tuple = (self.client_id, self.client_secret)
+
+        response = self._request(
+            method='POST',
+            url=(self.url + self.OPERATION_PATH) if self.url else self.url,
+            headers=headers,
+            data=data,
+            auth_tuple=auth_tuple,
+            proxies=self.proxies)
+        return response
+
+    def set_client_id_and_secret(self, client_id: str, client_secret: str) -> None:
+        """Set the client_id and client_secret.
+
+        Args:
+            client_id: The client id to be used for token requests.
+            client_secret: The client secret to be used for token requests.
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def set_headers(self, headers: Dict[str, str]) -> None:
+        """Headers to be sent with every CP4D token request.
+
+        Args:
+            headers: Headers to be sent with every IAM token request.
+        """
+        if isinstance(headers, dict):
+            self.headers = headers
+        else:
+            raise TypeError('headers must be a dictionary')
+
+    def _save_token_info(self, token_response: dict) -> None:
+        super()._save_token_info(token_response)
+
+        self.refresh_token = token_response.get("refresh_token")
+
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
+        """Sets the proxies the token manager will use to communicate with IAM on behalf of the host.
+
+        Args:
+            proxies: Proxies to use for communicating with IAM.
+            proxies.http (str, optional): The proxy endpoint to use for HTTP requests.
+            proxies.https (str, optional): The proxy endpoint to use for HTTPS requests.
+        """
+        if isinstance(proxies, dict):
+            self.proxies = proxies
+        else:
+            raise TypeError('proxies must be a dictionary')
+
+    def set_scope(self, value: str) -> None:
+        """Sets the "scope" parameter to use when fetching the bearer token from the IAM token server.
+
+        Args:
+            value: A space seperated string that makes up the scope parameter.
+        """
+        self.scope = value

--- a/ibm_cloud_sdk_core/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/iam_token_manager.py
@@ -15,14 +15,12 @@
 # limitations under the License.
 
 from typing import Dict, Optional
-from .jwt_token_manager import JWTTokenManager
 
-# pylint: disable=too-many-instance-attributes
-class IAMTokenManager(JWTTokenManager):
+from .iam_request_based_token_manager import IAMRequestBasedTokenManager
+
+class IAMTokenManager(IAMRequestBasedTokenManager):
     """The IAMTokenManager takes an api key and performs the necessary interactions with
     the IAM token service to obtain and store a suitable bearer token. Additionally, the IAMTokenManager
-    will retrieve bearer tokens via basic auth using a supplied client_id and client_secret pair.
-
     If the current stored bearer token has expired a new bearer token will be retrieved.
 
     Attributes:
@@ -60,13 +58,6 @@ class IAMTokenManager(JWTTokenManager):
         scope: The "scope" to use when fetching the bearer token from the IAM token server.
         This can be used to obtain an access token with a specific scope.
     """
-    DEFAULT_IAM_URL = 'https://iam.cloud.ibm.com'
-    CONTENT_TYPE = 'application/x-www-form-urlencoded'
-    OPERATION_PATH = "/identity/token"
-    REQUEST_TOKEN_GRANT_TYPE = 'urn:ibm:params:oauth:grant-type:apikey'
-    REQUEST_TOKEN_RESPONSE_TYPE = 'cloud_iam'
-    TOKEN_NAME = 'access_token'
-    SCOPE = 'scope'
 
     def __init__(self,
                  apikey: str,
@@ -78,103 +69,13 @@ class IAMTokenManager(JWTTokenManager):
                  headers: Optional[Dict[str, str]] = None,
                  proxies: Optional[Dict[str, str]] = None,
                  scope: Optional[str] = None) -> None:
-        self.apikey = apikey
-        if not url:
-            url = self.DEFAULT_IAM_URL
-        if url.endswith(self.OPERATION_PATH):
-            url = url[:-len(self.OPERATION_PATH)]
-        self.url = url
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.headers = headers
-        self.refresh_token = None
-        self.proxies = proxies
-        self.scope = scope
         super().__init__(
-            self.url, disable_ssl_verification=disable_ssl_verification, token_name=self.TOKEN_NAME)
+            url=url, client_id=client_id, client_secret=client_secret,
+            disable_ssl_verification=disable_ssl_verification, headers=headers, proxies=proxies, scope=scope)
 
-    def request_token(self) -> dict:
-        """Request an IAM OAuth token given an API Key.
+        self.apikey = apikey
 
-        If client_id and client_secret are specified use their values as a user and pass auth set
-        according to WHATWG url spec.
-
-        Returns:
-             A dictionary containing the bearer token to be subsequently used service requests.
-        """
-        headers = {
-            'Content-type': self.CONTENT_TYPE,
-            'Accept': 'application/json'
-        }
-        if self.headers is not None and isinstance(self.headers, dict):
-            headers.update(self.headers)
-
-        data = {
-            'grant_type': self.REQUEST_TOKEN_GRANT_TYPE,
-            'apikey': self.apikey,
-            'response_type': self.REQUEST_TOKEN_RESPONSE_TYPE
-        }
-
-        if self.scope is not None and self.scope:
-            data[self.SCOPE] = self.scope
-
-        auth_tuple = None
-        # If both the client_id and secret were specified by the user, then use them
-        if self.client_id and self.client_secret:
-            auth_tuple = (self.client_id, self.client_secret)
-
-        response = self._request(
-            method='POST',
-            url=(self.url + self.OPERATION_PATH) if self.url else self.url,
-            headers=headers,
-            data=data,
-            auth_tuple=auth_tuple,
-            proxies=self.proxies)
-        return response
-
-    def set_client_id_and_secret(self, client_id: str, client_secret: str) -> None:
-        """Set the client_id and client_secret.
-
-        Args:
-            client_id: The client id to be used for token requests.
-            client_secret: The client secret to be used for token requests.
-        """
-        self.client_id = client_id
-        self.client_secret = client_secret
-
-    def set_headers(self, headers: Dict[str, str]) -> None:
-        """Headers to be sent with every CP4D token request.
-
-        Args:
-            headers: Headers to be sent with every IAM token request.
-        """
-        if isinstance(headers, dict):
-            self.headers = headers
-        else:
-            raise TypeError('headers must be a dictionary')
-
-    def _save_token_info(self, token_response: dict) -> None:
-        super()._save_token_info(token_response)
-
-        self.refresh_token = token_response.get("refresh_token")
-
-    def set_proxies(self, proxies: Dict[str, str]) -> None:
-        """Sets the proxies the token manager will use to communicate with IAM on behalf of the host.
-
-        Args:
-            proxies: Proxies to use for communicating with IAM.
-            proxies.http (str, optional): The proxy endpoint to use for HTTP requests.
-            proxies.https (str, optional): The proxy endpoint to use for HTTPS requests.
-        """
-        if isinstance(proxies, dict):
-            self.proxies = proxies
-        else:
-            raise TypeError('proxies must be a dictionary')
-
-    def set_scope(self, value: str) -> None:
-        """Sets the "scope" parameter to use when fetching the bearer token from the IAM token server.
-
-        Args:
-            value: A space seperated string that makes up the scope parameter.
-        """
-        self.scope = value
+        # Set API key related data.
+        self.request_payload['grant_type'] = 'urn:ibm:params:oauth:grant-type:apikey'
+        self.request_payload['apikey'] = self.apikey
+        self.request_payload['response_type'] = 'cloud_iam'

--- a/ibm_cloud_sdk_core/token_managers/__init__.py
+++ b/ibm_cloud_sdk_core/token_managers/__init__.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+# Copyright 2021 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
@@ -16,6 +16,7 @@
 
 import json
 from typing import Dict, Optional
+
 from .jwt_token_manager import JWTTokenManager
 
 

--- a/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional
 
 from .jwt_token_manager import JWTTokenManager
 
+
 class IAMRequestBasedTokenManager(JWTTokenManager):
     """The IamRequestBasedTokenManager class contains code relevant to any token manager that
     interacts with the IAM service to manage a token. It stores information relevant to all

--- a/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
@@ -96,7 +96,7 @@ class IAMRequestBasedTokenManager(JWTTokenManager):
              A dictionary containing the bearer token to be subsequently used service requests.
         """
         headers = {
-            'Content-type': 'applicaton/x-www-form-urlencoded',
+            'Content-type': 'application/x-www-form-urlencoded',
             'Accept': 'application/json'
         }
         if self.headers is not None and isinstance(self.headers, dict):

--- a/ibm_cloud_sdk_core/token_managers/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_token_manager.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional
 
 from .iam_request_based_token_manager import IAMRequestBasedTokenManager
 
+
 class IAMTokenManager(IAMRequestBasedTokenManager):
     """The IAMTokenManager takes an api key and performs the necessary interactions with
     the IAM token service to obtain and store a suitable bearer token. Additionally, the IAMTokenManager

--- a/ibm_cloud_sdk_core/token_managers/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/jwt_token_manager.py
@@ -19,11 +19,9 @@ from typing import Optional
 
 import jwt
 import requests
+
 from .token_manager import TokenManager
 from ..api_exception import ApiException
-
-
-# pylint: disable=too-many-instance-attributes
 
 
 class JWTTokenManager(TokenManager, ABC):

--- a/ibm_cloud_sdk_core/token_managers/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/jwt_token_manager.py
@@ -19,8 +19,8 @@ from typing import Optional
 
 import jwt
 import requests
-from .api_exception import ApiException
 from .token_manager import TokenManager
+from ..api_exception import ApiException
 
 
 # pylint: disable=too-many-instance-attributes

--- a/ibm_cloud_sdk_core/token_managers/token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/token_manager.py
@@ -21,7 +21,7 @@ from threading import Lock
 import time
 import requests
 
-from .api_exception import ApiException
+from ..api_exception import ApiException
 
 
 # pylint: disable=too-many-instance-attributes

--- a/ibm_cloud_sdk_core/token_managers/token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/token_manager.py
@@ -15,17 +15,16 @@
 # limitations under the License.
 
 
+import time
 from abc import ABC, abstractmethod
 from threading import Lock
 
-import time
 import requests
 
 from ..api_exception import ApiException
 
 
 # pylint: disable=too-many-instance-attributes
-
 class TokenManager(ABC):
     """An abstract class to contain functionality for parsing, storing, and requesting tokens.
 

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -134,6 +134,7 @@ def string_to_datetime_list(string_list: List[str]) -> List[datetime.datetime]:
         datetime_list.append(string_to_datetime(string_val))
     return datetime_list
 
+
 def datetime_to_string_list(datetime_list: List[datetime.datetime]) -> List[str]:
     """Convert a list of datetime objects to a list of strings.
 
@@ -150,6 +151,7 @@ def datetime_to_string_list(datetime_list: List[datetime.datetime]) -> List[str]
     for datetime_val in datetime_list:
         string_list.append(datetime_to_string(datetime_val))
     return string_list
+
 
 def date_to_string(val: datetime.date) -> str:
     """Convert a date object to string.
@@ -176,6 +178,7 @@ def string_to_date(string: str) -> datetime.date:
     """
     return date_parser.parse(string).date()
 
+
 def get_query_param(url_str: str, param: str) -> str:
     """Return a query parameter value from url_str
 
@@ -199,6 +202,7 @@ def get_query_param(url_str: str, param: str) -> str:
     query = parse_qs(url.query, strict_parsing=True)
     values = query.get(param)
     return values[0] if values else None
+
 
 def convert_model(val: any) -> dict:
     """Convert a model object into an equivalent dict.

--- a/test/test_api_exception.py
+++ b/test/test_api_exception.py
@@ -1,8 +1,11 @@
 # coding=utf-8
 import json
-import responses
+
 import requests
+import responses
+
 from ibm_cloud_sdk_core import ApiException
+
 
 @responses.activate
 def test_api_exception():

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -1,23 +1,25 @@
 # coding=utf-8
 # pylint: disable=missing-docstring,protected-access,too-few-public-methods
+import gzip
 import json
-import time
 import os
+import tempfile
+import time
 from shutil import copyfile
 from typing import Optional
-import gzip
-import tempfile
+from urllib3.exceptions import ConnectTimeoutError, MaxRetryError
+
+import jwt
 import pytest
 import responses
 import requests
-import jwt
-from urllib3.exceptions import ConnectTimeoutError, MaxRetryError
-from ibm_cloud_sdk_core import BaseService, DetailedResponse
+
 from ibm_cloud_sdk_core import ApiException
+from ibm_cloud_sdk_core import BaseService, DetailedResponse
 from ibm_cloud_sdk_core import CP4DTokenManager
+from ibm_cloud_sdk_core import get_authenticator_from_environment
 from ibm_cloud_sdk_core.authenticators import (IAMAuthenticator, NoAuthAuthenticator, Authenticator,
                                                BasicAuthenticator, CloudPakForDataAuthenticator)
-from ibm_cloud_sdk_core import get_authenticator_from_environment
 from ibm_cloud_sdk_core.utils import strip_extra_slashes
 
 

--- a/test/test_basic_authenticator.py
+++ b/test/test_basic_authenticator.py
@@ -1,6 +1,8 @@
 # pylint: disable=missing-docstring
 import pytest
+
 from ibm_cloud_sdk_core.authenticators import BasicAuthenticator
+
 
 def test_basic_authenticator():
     authenticator = BasicAuthenticator('my_username', 'my_password')
@@ -11,6 +13,7 @@ def test_basic_authenticator():
     request = {'headers': {}}
     authenticator.authenticate(request)
     assert request['headers']['Authorization'] == 'Basic bXlfdXNlcm5hbWU6bXlfcGFzc3dvcmQ='
+
 
 def test_basic_authenticator_validate_failed():
     with pytest.raises(ValueError) as err:

--- a/test/test_bearer_authenticator.py
+++ b/test/test_bearer_authenticator.py
@@ -3,6 +3,7 @@ import pytest
 
 from ibm_cloud_sdk_core.authenticators import BearerTokenAuthenticator
 
+
 def test_bearer_authenticator():
     authenticator = BearerTokenAuthenticator('my_bearer_token')
     assert authenticator is not None
@@ -14,6 +15,7 @@ def test_bearer_authenticator():
     request = {'headers': {}}
     authenticator.authenticate(request)
     assert request['headers']['Authorization'] == 'Bearer james bond'
+
 
 def test_bearer_validate_failed():
     with pytest.raises(ValueError) as err:

--- a/test/test_cp4d_authenticator.py
+++ b/test/test_cp4d_authenticator.py
@@ -1,9 +1,9 @@
 # pylint: disable=missing-docstring
 import json
 
+import jwt
 import pytest
 import responses
-import jwt
 
 from ibm_cloud_sdk_core.authenticators import CloudPakForDataAuthenticator
 

--- a/test/test_cp4d_token_manager.py
+++ b/test/test_cp4d_token_manager.py
@@ -2,9 +2,11 @@
 import json
 import time
 
-import responses
 import jwt
+import responses
+
 from ibm_cloud_sdk_core import CP4DTokenManager
+
 
 @responses.activate
 def test_request_token():

--- a/test/test_detailed_response.py
+++ b/test/test_detailed_response.py
@@ -4,11 +4,14 @@ import json
 
 import responses
 import requests
+
 from ibm_cloud_sdk_core import DetailedResponse
+
 
 def clean(val):
     """Eliminate all whitespace and convert single to double quotes"""
     return val.translate(str.maketrans('', '', ' \n\t\r')).replace("'", "\"")
+
 
 @responses.activate
 def test_detailed_response_dict():
@@ -30,6 +33,7 @@ def test_detailed_response_dict():
     assert clean(detailed_response.get_result().__str__()) in response_str
     #assert clean(detailed_response.get_headers().__str__()) in response_str
     assert clean(detailed_response.get_status_code().__str__()) in response_str
+
 
 @responses.activate
 def test_detailed_response_list():

--- a/test/test_iam_authenticator.py
+++ b/test/test_iam_authenticator.py
@@ -41,6 +41,9 @@ def test_iam_authenticator():
     authenticator.set_proxies({'dummy': 'proxies'})
     assert authenticator.token_manager.proxies == {'dummy': 'proxies'}
 
+    authenticator.set_disable_ssl_verification(True)
+    assert authenticator.token_manager.disable_ssl_verification
+
 
 def test_iam_authenticator_with_scope():
     authenticator = IAMAuthenticator(apikey='my_apikey', scope='scope1 scope2')

--- a/test/test_iam_authenticator.py
+++ b/test/test_iam_authenticator.py
@@ -1,9 +1,9 @@
 # pylint: disable=missing-docstring
 import json
 
+import jwt
 import pytest
 import responses
-import jwt
 
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 

--- a/test/test_iam_token_manager.py
+++ b/test/test_iam_token_manager.py
@@ -2,9 +2,9 @@
 import os
 import time
 
-import responses
 import jwt
 import pytest
+import responses
 
 from ibm_cloud_sdk_core import IAMTokenManager, ApiException, get_authenticator_from_environment
 

--- a/test/test_jwt_token_manager.py
+++ b/test/test_jwt_token_manager.py
@@ -2,10 +2,12 @@
 import time
 import threading
 from typing import Optional
+
 import jwt
 import pytest
 
 from ibm_cloud_sdk_core import JWTTokenManager, DetailedResponse
+
 
 class JWTTokenManagerMockImpl(JWTTokenManager):
     def __init__(self, url: Optional[str] = None, access_token: Optional[str] = None) -> None:
@@ -45,8 +47,10 @@ class JWTTokenManagerMockImpl(JWTTokenManager):
         time.sleep(0.5)
         return response
 
+
 def _get_current_time() -> int:
     return int(time.time())
+
 
 def test_get_token():
     url = "https://iam.cloud.ibm.com/identity/token"
@@ -70,6 +74,7 @@ def test_get_token():
     assert token != "old_dummy"
     assert token_manager.request_count == 2
 
+
 def test_paced_get_token():
     url = "https://iam.cloud.ibm.com/identity/token"
     token_manager = JWTTokenManagerMockImpl(url)
@@ -82,6 +87,7 @@ def test_paced_get_token():
         thread.join()
     assert token_manager.request_count == 1
 
+
 def test_is_token_expired():
     token_manager = JWTTokenManagerMockImpl(None, access_token=None)
     assert token_manager._is_token_expired() is True
@@ -90,10 +96,12 @@ def test_is_token_expired():
     token_manager.expire_time = _get_current_time() - 3600
     assert token_manager._is_token_expired()
 
+
 def test_abstract_class_instantiation():
     with pytest.raises(TypeError) as err:
         JWTTokenManager(None)
     assert str(err.value).startswith("Can't instantiate abstract class JWTTokenManager with abstract")
+
 
 def test_disable_ssl_verification():
     token_manager = JWTTokenManagerMockImpl('https://iam.cloud.ibm.com/identity/token')

--- a/test/test_no_auth_authenticator.py
+++ b/test/test_no_auth_authenticator.py
@@ -2,6 +2,7 @@
 
 from ibm_cloud_sdk_core.authenticators import NoAuthAuthenticator
 
+
 def test_no_auth_authenticator():
     authenticator = NoAuthAuthenticator()
     assert authenticator is not None

--- a/test/test_token_manager.py
+++ b/test/test_token_manager.py
@@ -21,7 +21,7 @@ from unittest import mock
 import pytest
 
 from ibm_cloud_sdk_core import ApiException
-from ibm_cloud_sdk_core.token_manager import TokenManager
+from ibm_cloud_sdk_core.token_managers.token_manager import TokenManager
 
 
 class MockTokenManager(TokenManager):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,9 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import datetime
+import os
 from typing import Optional
+
 import pytest
 
 from ibm_cloud_sdk_core import string_to_datetime, datetime_to_string, get_authenticator_from_environment
@@ -117,6 +118,7 @@ def test_datetime_to_string():
     res = datetime_to_string(date)
     assert res == '2017-03-06T16:00:04.159338Z'
 
+
 def test_string_to_datetime_list():
     # Assert ValueError is raised for invalid argument type
     with pytest.raises(ValueError):
@@ -175,12 +177,14 @@ def test_datetime_to_string_list():
     res = datetime_to_string_list(date_list)
     assert res == [ '2017-03-06T16:00:04.159338Z', '2017-03-06T16:00:04.159338Z' ]
 
+
 def test_date_conversion():
     date = string_to_date('2017-03-06')
     assert date.day == 6
     res = date_to_string(date)
     assert res == '2017-03-06'
     assert date_to_string(None) is None
+
 
 def test_get_query_param():
     # Relative URL
@@ -222,6 +226,7 @@ def test_get_query_param():
     except ValueError:
         # This is okay.
         pass
+
 
 def test_convert_model():
     class MockModel:

--- a/test_integration/test_cp4d_authenticator_integration.py
+++ b/test_integration/test_cp4d_authenticator_integration.py
@@ -12,6 +12,7 @@ from ibm_cloud_sdk_core import get_authenticator_from_environment
 
 IBM_CREDENTIALS_FILE = '../resources/ibm-credentials-cp4dtest.env'
 
+
 def test_cp4d_authenticator_password():
     file_path = os.path.join(
         os.path.dirname(__file__), IBM_CREDENTIALS_FILE)
@@ -26,6 +27,7 @@ def test_cp4d_authenticator_password():
     authenticator.authenticate(request)
     assert request['headers']['Authorization'] is not None
     assert 'Bearer' in request['headers']['Authorization']
+
 
 def test_cp4d_authenticator_apikey():
     file_path = os.path.join(


### PR DESCRIPTION
This PR introduces two new classes: `IAMRequestBasedTokenManager` and `IAMRequestBasedAuthenticator`. These contain common functionalities for IAM auth based flows.

I haven't changed the tests on purpose. (Well, there is a minor change to fix the codecov patch check). The reason is to make sure that no interface change has been made, so everything is working just like before.