### PR TITLE
fix: encode serialized JSON string as UTF-8

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -18,7 +18,6 @@ import gzip
 import json as json_import
 import logging
 import platform
-import sys
 from http.cookiejar import CookieJar
 from os.path import basename
 from typing import Dict, List, Optional, Tuple, Union
@@ -373,14 +372,13 @@ class BaseService:
         params = cleanup_values(params)
         request['params'] = params
 
-        if sys.version_info >= (3, 0) and isinstance(data, str):
+        if isinstance(data, str):
             data = data.encode('utf-8')
-
-        if data and isinstance(data, dict):
+        elif isinstance(data, dict) and data:
             data = remove_null_values(data)
             if headers.get('content-type') is None:
                 headers.update({'content-type': 'application/json'})
-            data = json_import.dumps(data)
+            data = json_import.dumps(data).encode('utf-8')
         request['data'] = data
 
         self.authenticator.authenticate(request)

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -786,8 +786,8 @@ def test_files_duplicate_parts():
 def test_json():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
     req = service.prepare_request('POST', url='', headers={
-                                  'X-opt-out': True}, data={'hello': 'world'})
-    assert req.get('data') == "{\"hello\": \"world\"}"
+                                  'X-opt-out': True}, data={'hello': 'world', 'fóó': 'bår'})
+    assert req.get('data') == b'{"hello": "world", "f\\u00f3\\u00f3": "b\\u00e5r"}'
 
 
 def test_trailing_slash():

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -119,6 +119,13 @@ def get_access_token() -> str:
     return access_token
 
 
+def test_invalid_authenticator():
+    with pytest.raises(ValueError) as err:
+        AnyServiceV1('2021-08-18')
+
+    assert str(err.value) == 'authenticator must be provided'
+
+
 @responses.activate
 def test_url_encoding():
     service = AnyServiceV1('2017-07-07', authenticator=NoAuthAuthenticator())
@@ -480,6 +487,10 @@ def test_misc_methods():
     res_str = service._convert_list(temp)
     assert res_str == 'default,123'
 
+    temp2 = 'default123'
+    res_str2 = service._convert_list(temp2)
+    assert res_str2 == temp2
+
 
 def test_default_headers():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
@@ -711,6 +722,18 @@ def test_reserved_keys(caplog):
     assert caplog.record_tuples[1][2] == '"url" has been removed from the request'
     assert caplog.record_tuples[2][2] == '"headers" has been removed from the request'
     assert caplog.record_tuples[3][2] == '"cookies" has been removed from the request'
+
+@responses.activate
+def test_ssl_error():
+    responses.add(
+        responses.GET,
+        'https://gateway.watsonplatform.net/test/api',
+        body=requests.exceptions.SSLError())
+    service = AnyServiceV1('2021-08-18', authenticator=NoAuthAuthenticator())
+    with pytest.raises(requests.exceptions.SSLError):
+        prepped = service.prepare_request('GET', url='')
+        service.send(prepped)
+
 
 def test_files_dict():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())


### PR DESCRIPTION
This PR adds encoding to the serialized JSON payload. We are already doing this if the payload is passed as a string.

In the generated SDKs, for example in the [Platform Services/Case Management](https://github.com/IBM/platform-services-python-sdk/blob/main/ibm_platform_services/case_management_v1.py#L217), we serialize the `data` dictionary and pass it to the `prepare_request` function as a string, therefore I think it's safe to add encoding here.