### PR TITLE
fix(retries): change default retry_interval to 1 second (was 0.1)

### DIFF
--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -605,7 +605,7 @@ def test_retry_config_default():
                           authenticator=NoAuthAuthenticator())
     service.enable_retries()
     assert service.retry_config.total == 4
-    assert service.retry_config.backoff_factor == 0.1
+    assert service.retry_config.backoff_factor == 1.0
     assert service.http_client.get_adapter('https://').max_retries.total == 4
 
     # Ensure retries fail after 4 retries


### PR DESCRIPTION
This commit changes the default value of the retry_interval
parameter (in the BaseService.enable_retries method) from 0.1
to 1.0.   This will result in default retry intervals
of 1, 2, 4, 8, ... seconds instead of 0.1, 0.2, 0.4, 0.8, ... seconds.
This change will align the python core retry support with Go.
Also added some detailed info in the docstring for the method as well.