### PR TITLE
fix: multiple IAM based authenticator overrides

### DIFF
--- a/ibm_cloud_sdk_core/token_managers/container_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/container_token_manager.py
@@ -114,7 +114,7 @@ class ContainerTokenManager(IAMRequestBasedTokenManager):
                       cr_token_filename)
 
         try:
-            with open(cr_token_filename, 'r') as file:
+            with open(cr_token_filename, 'r', encoding='utf-8') as file:
                 cr_token = file.read()
             return cr_token
         # pylint: disable=broad-except

--- a/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
@@ -19,6 +19,7 @@ from typing import Dict, Optional
 from .jwt_token_manager import JWTTokenManager
 
 
+#pylint: disable=too-many-instance-attributes
 class IAMRequestBasedTokenManager(JWTTokenManager):
     """The IamRequestBasedTokenManager class contains code relevant to any token manager that
     interacts with the IAM service to manage a token. It stores information relevant to all

--- a/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
@@ -62,8 +62,6 @@ class IAMRequestBasedTokenManager(JWTTokenManager):
     DEFAULT_IAM_URL = 'https://iam.cloud.ibm.com'
     OPERATION_PATH = "/identity/token"
 
-    request_payload = {}
-
     def __init__(self,
                  url: Optional[str] = None,
                  client_id: Optional[str] = None,
@@ -83,6 +81,7 @@ class IAMRequestBasedTokenManager(JWTTokenManager):
         self.refresh_token = None
         self.proxies = proxies
         self.scope = scope
+        self.request_payload = {}
         super().__init__(
             self.url, disable_ssl_verification=disable_ssl_verification, token_name='access_token')
 

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -314,7 +314,7 @@ def __read_from_credential_file(service_name: str,
     config = {}
     if credential_file_path is not None:
         try:
-            with open(credential_file_path, 'r') as fobj:
+            with open(credential_file_path, 'r', encoding='utf-8') as fobj:
                 for line in fobj:
                     key_val = line.strip().split(separator, 1)
                     if len(key_val) == 2:

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -134,7 +134,7 @@ def test_url_encoding():
     path0 = ' \"<>^`{}|/\\?#%[]'
     path0_encoded = '%20%22%3C%3E%5E%60%7B%7D%7C%2F%5C%3F%23%25%5B%5D'
     # All non-ASCII chars _must_ be encoded in path segments
-    path1 = u'比萨浇头'.encode('utf8')  # "pizza toppings"
+    path1 = '比萨浇头'.encode('utf8')  # "pizza toppings"
     path1_encoded = '%E6%AF%94%E8%90%A8%E6%B5%87%E5%A4%B4'
 
     path_encoded = '/v1/foo/' + path0_encoded + '/bar/' + path1_encoded + '/baz'
@@ -741,7 +741,7 @@ def test_files_dict():
     form_data = {}
     with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r') as file:
+            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r', encoding='utf-8') as file:
         form_data['file1'] = (None, file, 'application/octet-stream')
     form_data['string1'] = (None, 'hello', 'text/plain')
     request = service.prepare_request(
@@ -762,7 +762,7 @@ def test_files_list():
     form_data = []
     with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r') as file:
+            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r', encoding='utf-8') as file:
         form_data.append(('file1', (None, file, 'application/octet-stream')))
     form_data.append(('string1', (None, 'hello', 'text/plain')))
     request = service.prepare_request(
@@ -783,17 +783,17 @@ def test_files_duplicate_parts():
     form_data = []
     with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r') as file:
+            os.path.dirname(__file__), '../resources/ibm-credentials-iam.env'), 'r', encoding='utf-8') as file:
         form_data.append(
             ('creds_file', (None, file, 'application/octet-stream')))
     with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-basic.env'), 'r') as file:
+            os.path.dirname(__file__), '../resources/ibm-credentials-basic.env'), 'r', encoding='utf-8') as file:
         form_data.append(
             ('creds_file', (None, file, 'application/octet-stream')))
     with open(
         os.path.join(
-            os.path.dirname(__file__), '../resources/ibm-credentials-bearer.env'), 'r') as file:
+            os.path.dirname(__file__), '../resources/ibm-credentials-bearer.env'), 'r', encoding='utf-8') as file:
         form_data.append(
             ('creds_file', (None, file, 'application/octet-stream')))
     request = service.prepare_request(

--- a/test/test_container_token_manager.py
+++ b/test/test_container_token_manager.py
@@ -37,7 +37,7 @@ def mock_iam_response(func):
 
         assert payload['cr_token'][0] == 'cr-token-1'
         assert payload['grant_type'][0] == 'urn:ibm:params:oauth:grant-type:cr-token'
-        assert payload['profile_name'][0] or payload['iam_profile_id']
+        assert payload.get('profile_name', [None])[0] or payload.get('profile_id', [None])[0]
 
         status_code = 200
 
@@ -264,12 +264,20 @@ def test_client_id_and_secret():
 def test_setter_methods():
     token_manager = ContainerTokenManager(
         cr_token_filename='bogus-cr-token-file',
-        iam_profile_id=MOCK_IAM_PROFILE_NAME,
+        iam_profile_name=MOCK_IAM_PROFILE_NAME,
     )
+
+    assert token_manager.iam_profile_id is None
+    assert token_manager.iam_profile_name == MOCK_IAM_PROFILE_NAME
+    assert token_manager.cr_token_filename == 'bogus-cr-token-file'
 
     token_manager.set_iam_profile_id('iam-id-123')
     token_manager.set_iam_profile_name(None)
     token_manager.set_cr_token_filename(cr_token_file)
+
+    assert token_manager.iam_profile_id == 'iam-id-123'
+    assert token_manager.iam_profile_name is None
+    assert token_manager.cr_token_filename == cr_token_file
 
     access_token = token_manager.get_token()
     assert access_token == TEST_ACCESS_TOKEN_1

--- a/test/test_detailed_response.py
+++ b/test/test_detailed_response.py
@@ -26,7 +26,7 @@ def test_detailed_response_dict():
                                          status_code=mock_response.status_code)
     assert detailed_response is not None
     assert detailed_response.get_result() == {'foobar': 'baz'}
-    assert detailed_response.get_headers() == {u'Content-Type': 'application/json'}
+    assert detailed_response.get_headers() == {'Content-Type': 'application/json'}
     assert detailed_response.get_status_code() == 200
 
     response_str = clean(detailed_response.__str__())
@@ -48,7 +48,7 @@ def test_detailed_response_list():
                                          status_code=mock_response.status_code)
     assert detailed_response is not None
     assert detailed_response.get_result() == ['foobar', 'baz']
-    assert detailed_response.get_headers() == {u'Content-Type': 'application/json'}
+    assert detailed_response.get_headers() == {'Content-Type': 'application/json'}
     assert detailed_response.get_status_code() == 200
 
     response_str = clean(detailed_response.__str__())

--- a/test/test_iam_authenticator.py
+++ b/test/test_iam_authenticator.py
@@ -142,3 +142,13 @@ def test_get_token():
     # Verify that the "get token" call contained the Host header.
     assert responses.calls[0].request.headers.get(
         'Host') == 'iam.cloud.ibm.com:443'
+
+
+def test_multiple_iam_authenticators():
+    authenticator_1 = IAMAuthenticator('my_apikey')
+    assert authenticator_1.token_manager.request_payload['apikey'] == 'my_apikey'
+
+    authenticator_2 = IAMAuthenticator('my_other_apikey')
+    assert authenticator_2.token_manager.request_payload['apikey'] == 'my_other_apikey'
+
+    assert authenticator_1.token_manager.request_payload['apikey'] == 'my_apikey'


### PR DESCRIPTION
This PR fixes an issue which happens when the user creates more than one IAM based authenticator in the same service/project/file. The cause of this issue is the `request_payload` class variable, because it should be an instance variable.
Tests have been added, fixed and improved.

Closes #123 

Update: there are also some unicode string and utf-8 encoding related changes in this PR to make the code compatible with the latest pylint release.