### PR TITLE
chore(build): use node 14 for new semantic-release

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,6 +8,7 @@ disable=
     too-many-arguments,
     unnecessary-pass,
     no-member,
+    consider-using-f-string
 
 [TYPECHECK]
 ignored-classes= responses

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-08-12T17:18:41Z",
+  "generated_at": "2021-10-13T21:20:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -67,34 +67,18 @@
   "results": {
     "Authentication.md": [
       {
-        "hashed_secret": "98635b2eaa2379f28cd6d72a38299f286b81b459",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 156,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "5eb942810a75ebc850972a89285d570d484c89c4",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 168,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
-        "hashed_secret": "4080eeeaf54faf879b9e8d99c49a8503f7e855bb",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 175,
-        "type": "Secret Keyword",
-        "verified_result": null
-      },
-      {
         "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 189,
+        "line_number": 66,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "98635b2eaa2379f28cd6d72a38299f286b81b459",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 297,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -102,7 +86,7 @@
         "hashed_secret": "47fcf185ee7e15fe05cae31fbe9e4ebe4a06a40d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 195,
+        "line_number": 328,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -374,7 +358,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.42.dss",
+  "version": "0.13.1+ibm.46.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 before_deploy:
 - pip3 install --editable .
 - pip3 install bumpversion
-- nvm install 12
+- nvm install 14
 - npm install @semantic-release/changelog
 - npm install @semantic-release/exec
 - npm install @semantic-release/git


### PR DESCRIPTION
This PR bumps us up to node v14 to accommodate the new semantic-release v18

For some reason, my initial change to bump node to v14 resulted in some additional lint warnings related to the use f-strings and failed the build.  I added another change to disable that lint check as a bit of research revealed that it's a dubious check to perform anyhow :)