### PR TITLE
feat: add authentication_type method to authenticators

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-10-13T21:20:56Z",
+  "generated_at": "2021-10-15T20:17:29Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -87,6 +87,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 328,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "ibm_cloud_sdk_core/authenticators/authenticator.py": [
+      {
+        "hashed_secret": "fdee05598fdd57ff8e9ae29e92c25a04f2c52fa6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -202,7 +212,7 @@
         "hashed_secret": "37e94c31b6a756ba2afd2fe9a9765172cd79ac47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 102,
+        "line_number": 103,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -246,7 +256,7 @@
         "hashed_secret": "5eb942810a75ebc850972a89285d570d484c89c4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 96,
+        "line_number": 97,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -254,7 +264,7 @@
         "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 136,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -274,7 +284,7 @@
         "hashed_secret": "4080eeeaf54faf879b9e8d99c49a8503f7e855bb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 73,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -282,7 +292,7 @@
         "hashed_secret": "37e94c31b6a756ba2afd2fe9a9765172cd79ac47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 93,
+        "line_number": 96,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -290,7 +300,7 @@
         "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 121,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -336,7 +346,7 @@
         "hashed_secret": "34a0a47a51d5bf739df0214450385e29ee7e9847",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 393,
+        "line_number": 417,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -344,7 +354,7 @@
         "hashed_secret": "2863fa4b5510c46afc2bd2998dfbc0cf3d6df032",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 469,
+        "line_number": 497,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -352,7 +362,7 @@
         "hashed_secret": "b9cad336062c0dc3bb30145b1a6697fccfe755a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 530,
+        "line_number": 558,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/ibm_cloud_sdk_core/authenticators/authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/authenticator.py
@@ -19,6 +19,16 @@ from abc import ABC, abstractmethod
 
 class Authenticator(ABC):
     """This interface defines the common methods and constants associated with an Authenticator implementation."""
+
+    # Constants representing the various authenticator types.
+    AUTHTYPE_BASIC = 'basic'
+    AUTHTYPE_BEARERTOKEN = 'bearerToken'
+    AUTHTYPE_IAM = 'iam'
+    AUTHTYPE_CONTAINER = 'container'
+    AUTHTYPE_CP4D = 'cp4d'
+    AUTHTYPE_NOAUTH = 'noAuth'
+    AUTHTYPE_UNKNOWN = 'unknown'
+
     @abstractmethod
     def authenticate(self, req: dict) -> None:
         """Perform the necessary authentication steps for the specified request.
@@ -40,3 +50,8 @@ class Authenticator(ABC):
         To be implemented by subclasses.
         """
         pass
+
+    # pylint: disable=R0201
+    def authentication_type(self) -> str:
+        """Returns the authenticator's type.  This method should be overridden by each authenticator implementation."""
+        return Authenticator.AUTHTYPE_UNKNOWN

--- a/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
@@ -35,7 +35,6 @@ class BasicAuthenticator(Authenticator):
     Raises:
         ValueError: The username or password is not specified or contains invalid characters.
     """
-    authentication_type = 'basic'
 
     def __init__(self, username: str, password: str) -> None:
         self.username = username
@@ -43,6 +42,9 @@ class BasicAuthenticator(Authenticator):
         self.validate()
         self.authorization_header = self.__construct_basic_auth_header()
 
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('basic')."""
+        return Authenticator.AUTHTYPE_BASIC
 
     def validate(self) -> None:
         """Validate username and password.
@@ -61,12 +63,11 @@ class BasicAuthenticator(Authenticator):
                 'The username and password shouldn\'t start or end with curly brackets or quotes. '
                 'Please remove any surrounding {, }, or \" characters.')
 
-
     def __construct_basic_auth_header(self) -> str:
         authstring = "{0}:{1}".format(self.username, self.password)
-        base64_authorization = base64.b64encode(authstring.encode('utf-8')).decode('utf-8')
+        base64_authorization = base64.b64encode(
+            authstring.encode('utf-8')).decode('utf-8')
         return 'Basic {0}'.format(base64_authorization)
-
 
     def authenticate(self, req: Request) -> None:
         """Add basic authentication information to a request.

--- a/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
@@ -33,11 +33,14 @@ class BearerTokenAuthenticator(Authenticator):
     Raises:
         ValueError: Bearer token is none.
     """
-    authentication_type = 'bearerToken'
 
     def __init__(self, bearer_token: str) -> None:
         self.bearer_token = bearer_token
         self.validate()
+
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('bearertoken')."""
+        return Authenticator.AUTHTYPE_BEARERTOKEN
 
     def validate(self) -> None:
         """Validate the bearer token.

--- a/ibm_cloud_sdk_core/authenticators/container_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/container_authenticator.py
@@ -18,6 +18,7 @@ from typing import Dict, Optional
 
 from .iam_request_based_authenticator import IAMRequestBasedAuthenticator
 from ..token_managers.container_token_manager import ContainerTokenManager
+from .authenticator import Authenticator
 
 
 class ContainerAuthenticator(IAMRequestBasedAuthenticator):
@@ -62,7 +63,6 @@ class ContainerAuthenticator(IAMRequestBasedAuthenticator):
             ValueError: Neither of iam_profile_name or iam_profile_idk are set,
             or client_id, and/or client_secret are not valid for IAM token requests.
     """
-    authentication_type = 'container'
 
     def __init__(self,
                  cr_token_filename: Optional[str] = None,
@@ -85,6 +85,10 @@ class ContainerAuthenticator(IAMRequestBasedAuthenticator):
             disable_ssl_verification=disable_ssl_verification, scope=scope, proxies=proxies, headers=headers)
 
         self.validate()
+
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('container')."""
+        return Authenticator.AUTHTYPE_CONTAINER
 
     def validate(self) -> None:
         """Validates the iam_profile_name, iam_profile_id, client_id, and client_secret for IAM token requests.

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -50,7 +50,6 @@ class CloudPakForDataAuthenticator(Authenticator):
         TypeError: The `disable_ssl_verification` is not a bool.
         ValueError: The username, password/apikey, and/or url are not valid for CP4D token requests.
     """
-    authenticationdict = 'cp4d'
 
     def __init__(self,
                  username: str = None,
@@ -71,6 +70,10 @@ class CloudPakForDataAuthenticator(Authenticator):
 
         self.validate()
 
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('cp4d')."""
+        return Authenticator.AUTHTYPE_CP4D
+
     def validate(self) -> None:
         """Validate username, password, and url for token requests.
 
@@ -85,7 +88,8 @@ class CloudPakForDataAuthenticator(Authenticator):
 
         if ((self.token_manager.password is None and self.token_manager.apikey is None)
                 or (self.token_manager.password is not None and self.token_manager.apikey is not None)):
-            raise ValueError('Exactly one of `apikey` or `password` must be specified.')
+            raise ValueError(
+                'Exactly one of `apikey` or `password` must be specified.')
 
         if self.token_manager.url is None:
             raise ValueError('The url shouldn\'t be None.')

--- a/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_authenticator.py
@@ -16,6 +16,7 @@
 
 from typing import Dict, Optional
 
+from .authenticator import Authenticator
 from .iam_request_based_authenticator import IAMRequestBasedAuthenticator
 from ..token_managers.iam_token_manager import IAMTokenManager
 from ..utils import has_bad_first_or_last_char
@@ -54,7 +55,6 @@ class IAMAuthenticator(IAMRequestBasedAuthenticator):
         TypeError: The `disable_ssl_verification` is not a bool.
         ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
     """
-    authentication_type = 'iam'
 
     def __init__(self,
                  apikey: str,
@@ -76,6 +76,10 @@ class IAMAuthenticator(IAMRequestBasedAuthenticator):
             headers=headers, proxies=proxies, scope=scope)
 
         self.validate()
+
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('iam')."""
+        return Authenticator.AUTHTYPE_IAM
 
     def validate(self) -> None:
         """Validates the apikey, client_id, and client_secret for IAM token requests.

--- a/ibm_cloud_sdk_core/authenticators/no_auth_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/no_auth_authenticator.py
@@ -19,7 +19,10 @@ from .authenticator import Authenticator
 
 class NoAuthAuthenticator(Authenticator):
     """Performs no authentication."""
-    authentication_type = 'noAuth'
+
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('noauth')."""
+        return Authenticator.AUTHTYPE_NOAUTH
 
     def validate(self) -> None:
         pass

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+# pylint: disable=missing-docstring
+
+from requests import Request
+from ibm_cloud_sdk_core.authenticators import Authenticator
+
+
+class TestAuthenticator(Authenticator):
+    """A test of the Authenticator base class"""
+
+    def validate(self) -> None:
+        """Simulated validate() method."""
+
+    def authenticate(self, req: Request) -> None:
+        """Simulated authenticate() method."""
+
+
+def test_authenticator():
+    authenticator = TestAuthenticator()
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_UNKNOWN

--- a/test/test_basic_authenticator.py
+++ b/test/test_basic_authenticator.py
@@ -1,12 +1,13 @@
 # pylint: disable=missing-docstring
 import pytest
 
-from ibm_cloud_sdk_core.authenticators import BasicAuthenticator
+from ibm_cloud_sdk_core.authenticators import BasicAuthenticator, Authenticator
 
 
 def test_basic_authenticator():
     authenticator = BasicAuthenticator('my_username', 'my_password')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_BASIC
     assert authenticator.username == 'my_username'
     assert authenticator.password == 'my_password'
 

--- a/test/test_bearer_authenticator.py
+++ b/test/test_bearer_authenticator.py
@@ -1,12 +1,13 @@
 # pylint: disable=missing-docstring
 import pytest
 
-from ibm_cloud_sdk_core.authenticators import BearerTokenAuthenticator
+from ibm_cloud_sdk_core.authenticators import BearerTokenAuthenticator, Authenticator
 
 
 def test_bearer_authenticator():
     authenticator = BearerTokenAuthenticator('my_bearer_token')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_BEARERTOKEN
     assert authenticator.bearer_token == 'my_bearer_token'
 
     authenticator.set_bearer_token('james bond')

--- a/test/test_container_authenticator.py
+++ b/test/test_container_authenticator.py
@@ -1,12 +1,13 @@
 # pylint: disable=missing-docstring
 import pytest
 
-from ibm_cloud_sdk_core.authenticators import ContainerAuthenticator
+from ibm_cloud_sdk_core.authenticators import ContainerAuthenticator, Authenticator
 
 
 def test_container_authenticator():
     authenticator = ContainerAuthenticator(iam_profile_name='iam-user-123')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_CONTAINER
     assert authenticator.token_manager.cr_token_filename is None
     assert authenticator.token_manager.iam_profile_name == 'iam-user-123'
     assert authenticator.token_manager.iam_profile_id is None

--- a/test/test_cp4d_authenticator.py
+++ b/test/test_cp4d_authenticator.py
@@ -5,13 +5,14 @@ import jwt
 import pytest
 import responses
 
-from ibm_cloud_sdk_core.authenticators import CloudPakForDataAuthenticator
+from ibm_cloud_sdk_core.authenticators import CloudPakForDataAuthenticator, Authenticator
 
 
 def test_cp4d_authenticator():
     authenticator = CloudPakForDataAuthenticator(
         'my_username', 'my_password', 'http://my_url')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_CP4D
     assert authenticator.token_manager.url == 'http://my_url/v1/authorize'
     assert authenticator.token_manager.username == 'my_username'
     assert authenticator.token_manager.password == 'my_password'
@@ -40,7 +41,7 @@ def test_cp4d_authenticator():
 
 def test_disable_ssl_verification():
     authenticator = CloudPakForDataAuthenticator(
-            'my_username', 'my_password', 'http://my_url', disable_ssl_verification=True)
+        'my_username', 'my_password', 'http://my_url', disable_ssl_verification=True)
     assert authenticator.token_manager.disable_ssl_verification is True
 
     authenticator.set_disable_ssl_verification(False)
@@ -54,7 +55,7 @@ def test_invalid_disable_ssl_verification_type():
     assert str(err.value) == 'disable_ssl_verification must be a bool'
 
     authenticator = CloudPakForDataAuthenticator(
-            'my_username', 'my_password', 'http://my_url')
+        'my_username', 'my_password', 'http://my_url')
     assert authenticator.token_manager.disable_ssl_verification is False
 
     with pytest.raises(TypeError) as err:

--- a/test/test_iam_authenticator.py
+++ b/test/test_iam_authenticator.py
@@ -5,12 +5,13 @@ import jwt
 import pytest
 import responses
 
-from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
+from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, Authenticator
 
 
 def test_iam_authenticator():
     authenticator = IAMAuthenticator(apikey='my_apikey')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.url == 'https://iam.cloud.ibm.com'
     assert authenticator.token_manager.client_id is None
     assert authenticator.token_manager.client_secret is None
@@ -46,7 +47,8 @@ def test_iam_authenticator():
 
 
 def test_disable_ssl_verification():
-    authenticator = IAMAuthenticator(apikey='my_apikey', disable_ssl_verification=True)
+    authenticator = IAMAuthenticator(
+        apikey='my_apikey', disable_ssl_verification=True)
     assert authenticator.token_manager.disable_ssl_verification is True
 
     authenticator.set_disable_ssl_verification(False)
@@ -55,7 +57,8 @@ def test_disable_ssl_verification():
 
 def test_invalid_disable_ssl_verification_type():
     with pytest.raises(TypeError) as err:
-        authenticator = IAMAuthenticator(apikey='my_apikey', disable_ssl_verification='True')
+        authenticator = IAMAuthenticator(
+            apikey='my_apikey', disable_ssl_verification='True')
     assert str(err.value) == 'disable_ssl_verification must be a bool'
 
     authenticator = IAMAuthenticator(apikey='my_apikey')

--- a/test/test_no_auth_authenticator.py
+++ b/test/test_no_auth_authenticator.py
@@ -1,12 +1,12 @@
 # pylint: disable=missing-docstring
 
-from ibm_cloud_sdk_core.authenticators import NoAuthAuthenticator
+from ibm_cloud_sdk_core.authenticators import NoAuthAuthenticator, Authenticator
 
 
 def test_no_auth_authenticator():
     authenticator = NoAuthAuthenticator()
     assert authenticator is not None
-    assert authenticator.authentication_type == 'noAuth'
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_NOAUTH
 
     authenticator.validate()
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -27,7 +27,7 @@ from ibm_cloud_sdk_core import string_to_date, date_to_string
 from ibm_cloud_sdk_core import convert_model, convert_list
 from ibm_cloud_sdk_core import get_query_param
 from ibm_cloud_sdk_core import read_external_sources
-from ibm_cloud_sdk_core.authenticators import BasicAuthenticator, IAMAuthenticator
+from ibm_cloud_sdk_core.authenticators import Authenticator, BasicAuthenticator, IAMAuthenticator
 
 
 def datetime_test(datestr: str, expected: str):
@@ -124,28 +124,33 @@ def test_string_to_datetime_list():
     with pytest.raises(ValueError):
         string_to_datetime_list(None)
     # If the specified string does not include a timezone, it is assumed to be UTC
-    date_list = string_to_datetime_list([ '2017-03-06 16:00:04.159338' ])
+    date_list = string_to_datetime_list(['2017-03-06 16:00:04.159338'])
     assert date_list[0].day == 6
     assert date_list[0].hour == 16
-    assert date_list[0].tzinfo.utcoffset(None) == datetime.timezone.utc.utcoffset(None)
+    assert date_list[0].tzinfo.utcoffset(
+        None) == datetime.timezone.utc.utcoffset(None)
     # Test date string with TZ specified as '+xxxx'
-    date_list = string_to_datetime_list([ '2017-03-06 16:00:04.159338+0600' ])
+    date_list = string_to_datetime_list(['2017-03-06 16:00:04.159338+0600'])
     assert date_list[0].day == 6
     assert date_list[0].hour == 16
     assert date_list[0].tzinfo.utcoffset(None).total_seconds() == 6 * 60 * 60
     # Test date string with TZ specified as 'Z'
-    date_list = string_to_datetime_list([ '2017-03-06 16:00:04.159338Z' ])
+    date_list = string_to_datetime_list(['2017-03-06 16:00:04.159338Z'])
     assert date_list[0].day == 6
     assert date_list[0].hour == 16
-    assert date_list[0].tzinfo.utcoffset(None) == datetime.timezone.utc.utcoffset(None)
+    assert date_list[0].tzinfo.utcoffset(
+        None) == datetime.timezone.utc.utcoffset(None)
     # Test multiple datetimes in a list
-    date_list = string_to_datetime_list([ '2017-03-06 16:00:04.159338', '2017-03-07 17:00:04.159338' ])
+    date_list = string_to_datetime_list(
+        ['2017-03-06 16:00:04.159338', '2017-03-07 17:00:04.159338'])
     assert date_list[0].day == 6
     assert date_list[0].hour == 16
-    assert date_list[0].tzinfo.utcoffset(None) == datetime.timezone.utc.utcoffset(None)
+    assert date_list[0].tzinfo.utcoffset(
+        None) == datetime.timezone.utc.utcoffset(None)
     assert date_list[1].day == 7
     assert date_list[1].hour == 17
-    assert date_list[1].tzinfo.utcoffset(None) == datetime.timezone.utc.utcoffset(None)
+    assert date_list[1].tzinfo.utcoffset(
+        None) == datetime.timezone.utc.utcoffset(None)
 
 
 def test_datetime_to_string_list():
@@ -157,25 +162,26 @@ def test_datetime_to_string_list():
     # If specified datetime list is empty, return empty list
     assert datetime_to_string_list([]) == []
     # If the specified date list item is "naive", it is interpreted as a UTC date
-    date_list = [ datetime.datetime(2017, 3, 6, 16, 0, 4, 159338) ]
+    date_list = [datetime.datetime(2017, 3, 6, 16, 0, 4, 159338)]
     res = datetime_to_string_list(date_list)
-    assert res == [ '2017-03-06T16:00:04.159338Z' ]
+    assert res == ['2017-03-06T16:00:04.159338Z']
     # Test date list item with UTC timezone
-    date_list = [ datetime.datetime(2017, 3, 6, 16, 0, 4, 159338,
-                             datetime.timezone.utc) ]
+    date_list = [datetime.datetime(2017, 3, 6, 16, 0, 4, 159338,
+                                   datetime.timezone.utc)]
     res = datetime_to_string_list(date_list)
-    assert res == [ '2017-03-06T16:00:04.159338Z' ]
+    assert res == ['2017-03-06T16:00:04.159338Z']
     # Test date list item with non-UTC timezone
     tzn = datetime.timezone(datetime.timedelta(hours=-6))
-    date_list = [ datetime.datetime(2017, 3, 6, 10, 0, 4, 159338, tzn) ]
+    date_list = [datetime.datetime(2017, 3, 6, 10, 0, 4, 159338, tzn)]
     res = datetime_to_string_list(date_list)
-    assert res == [ '2017-03-06T16:00:04.159338Z' ]
+    assert res == ['2017-03-06T16:00:04.159338Z']
     # Test specified date list with multiple items
-    date_list = [ datetime.datetime(2017, 3, 6, 16, 0, 4, 159338),
-                  datetime.datetime(2017, 3, 6, 16, 0, 4, 159338,
-                        datetime.timezone.utc) ]
+    date_list = [datetime.datetime(2017, 3, 6, 16, 0, 4, 159338),
+                 datetime.datetime(2017, 3, 6, 16, 0, 4, 159338,
+                                   datetime.timezone.utc)]
     res = datetime_to_string_list(date_list)
-    assert res == [ '2017-03-06T16:00:04.159338Z', '2017-03-06T16:00:04.159338Z' ]
+    assert res == ['2017-03-06T16:00:04.159338Z',
+                   '2017-03-06T16:00:04.159338Z']
 
 
 def test_date_conversion():
@@ -281,6 +287,7 @@ def test_get_authenticator_from_credential_file():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('ibm watson')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == '5678efgh'
     assert authenticator.token_manager.url == 'https://iam.cloud.ibm.com'
     assert authenticator.token_manager.client_id is None
@@ -294,6 +301,7 @@ def test_get_authenticator_from_credential_file():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('watson')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_BASIC
     assert authenticator.username == 'my_username'
     del os.environ['IBM_CREDENTIALS_FILE']
 
@@ -302,6 +310,7 @@ def test_get_authenticator_from_credential_file():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('service 1')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_CONTAINER
     assert authenticator.token_manager.cr_token_filename == 'crtoken.txt'
     assert authenticator.token_manager.iam_profile_name == 'iam-user-123'
     assert authenticator.token_manager.iam_profile_id == 'iam-id-123'
@@ -313,6 +322,7 @@ def test_get_authenticator_from_credential_file():
 
     authenticator = get_authenticator_from_environment('service 2')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_CONTAINER
     assert authenticator.token_manager.cr_token_filename is None
     assert authenticator.token_manager.iam_profile_name == 'iam-user-123'
     assert authenticator.token_manager.iam_profile_id is None
@@ -328,6 +338,7 @@ def test_get_authenticator_from_credential_file():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('watson')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_CP4D
     assert authenticator.token_manager.username == 'my_username'
     assert authenticator.token_manager.password == 'my_password'
     assert authenticator.token_manager.url == 'https://my_url/v1/authorize'
@@ -340,6 +351,7 @@ def test_get_authenticator_from_credential_file():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('watson')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_NOAUTH
     del os.environ['IBM_CREDENTIALS_FILE']
 
     file_path = os.path.join(os.path.dirname(__file__),
@@ -347,6 +359,7 @@ def test_get_authenticator_from_credential_file():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('watson')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_BEARERTOKEN
     assert authenticator.bearer_token is not None
     del os.environ['IBM_CREDENTIALS_FILE']
 
@@ -355,6 +368,7 @@ def test_get_authenticator_from_credential_file():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('service_1')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == 'V4HXmoUtMjohnsnow=KotN'
     assert authenticator.token_manager.client_id == 'somefake========id'
     assert authenticator.token_manager.client_secret == '==my-client-secret=='
@@ -369,6 +383,7 @@ def test_get_authenticator_from_credential_file_scope():
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('service_2')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == 'V4HXmoUtMjohnsnow=KotN'
     assert authenticator.token_manager.client_id == 'somefake========id'
     assert authenticator.token_manager.client_secret == '==my-client-secret=='
@@ -381,12 +396,21 @@ def test_get_authenticator_from_env_variables():
     os.environ['TEST_APIKEY'] = '5678efgh'
     authenticator = get_authenticator_from_environment('test')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == '5678efgh'
     del os.environ['TEST_APIKEY']
+
+    os.environ['TEST_IAM_PROFILE_ID'] = 'iam-profile-id1'
+    authenticator = get_authenticator_from_environment('test')
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_CONTAINER
+    assert authenticator.token_manager.iam_profile_id == 'iam-profile-id1'
+    del os.environ['TEST_IAM_PROFILE_ID']
 
     os.environ['SERVICE_1_APIKEY'] = 'V4HXmoUtMjohnsnow=KotN'
     authenticator = get_authenticator_from_environment('service_1')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == 'V4HXmoUtMjohnsnow=KotN'
     del os.environ['SERVICE_1_APIKEY']
 
@@ -409,6 +433,7 @@ def test_vcap_credentials():
     os.environ['VCAP_SERVICES'] = vcap_services
     authenticator = get_authenticator_from_environment('test')
     assert isinstance(authenticator, BasicAuthenticator)
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_BASIC
     assert authenticator.username == 'bogus username'
     assert authenticator.password == 'bogus password'
     del os.environ['VCAP_SERVICES']
@@ -420,6 +445,7 @@ def test_vcap_credentials():
     os.environ['VCAP_SERVICES'] = vcap_services
     authenticator = get_authenticator_from_environment('test')
     assert isinstance(authenticator, IAMAuthenticator)
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == 'bogus apikey'
     del os.environ['VCAP_SERVICES']
 
@@ -430,6 +456,7 @@ def test_vcap_credentials():
     os.environ['VCAP_SERVICES'] = vcap_services
     authenticator = get_authenticator_from_environment('test')
     assert isinstance(authenticator, IAMAuthenticator)
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == 'bogus apikey'
     del os.environ['VCAP_SERVICES']
 
@@ -442,6 +469,7 @@ def test_vcap_credentials():
     os.environ['VCAP_SERVICES'] = vcap_services
     authenticator = get_authenticator_from_environment('testname')
     assert isinstance(authenticator, BasicAuthenticator)
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_BASIC
     assert authenticator.username == 'bogus username'
     assert authenticator.password == 'bogus password'
     del os.environ['VCAP_SERVICES']
@@ -530,6 +558,7 @@ def test_multi_word_service_name():
     os.environ['PERSONALITY_INSIGHTS_APIKEY'] = '5678efgh'
     authenticator = get_authenticator_from_environment('personality-insights')
     assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM
     assert authenticator.token_manager.apikey == '5678efgh'
     del os.environ['PERSONALITY_INSIGHTS_APIKEY']
 


### PR DESCRIPTION
This commit adds a new method ('authentication_type()') to
the Authenticator base class, and each authenticator implementation
(subclasses of Authenticator).
The function will return a string indicating the
authenticator type ('basic', 'iam', etc.).
This brings the python core in line with the Go, Java and Node cores.