### PR TITLE
fix: strip trailing slashes in BaseService.set_service_url

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -224,6 +224,8 @@ class BaseService:
                 'The service url shouldn\'t start or end with curly brackets or quotes. '
                 'Be sure to remove any {} and \" characters surrounding your service url'
             )
+        if service_url is not None:
+            service_url = service_url.rstrip('/')
         self.service_url = service_url
 
     def get_http_client(self) -> requests.sessions.Session:
@@ -368,6 +370,10 @@ class BaseService:
         # validate the service url is set
         if not self.service_url:
             raise ValueError('The service_url is required')
+
+        # Combine the service_url and operation path to form the request url.
+        # Note: we have already stripped any trailing slashes from the service_url
+        # and we know that the operation path ('url') will start with a slash.
         request['url'] = strip_extra_slashes(self.service_url + url)
 
         headers = remove_null_values(headers) if headers else {}

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -28,6 +28,7 @@ from ibm_cloud_sdk_core import convert_model, convert_list
 from ibm_cloud_sdk_core import get_query_param
 from ibm_cloud_sdk_core import read_external_sources
 from ibm_cloud_sdk_core.authenticators import Authenticator, BasicAuthenticator, IAMAuthenticator
+from ibm_cloud_sdk_core.utils import strip_extra_slashes
 
 
 def datetime_test(datestr: str, expected: str):
@@ -616,3 +617,18 @@ def test_read_external_sources_2():
 
     config = read_external_sources('service_1')
     assert config.get('URL') == 'service1.com/api'
+
+
+def test_strip_extra_slashes():
+    assert strip_extra_slashes('') == ''
+    assert strip_extra_slashes('//') == '/'
+    assert strip_extra_slashes('/////') == '/'
+    assert strip_extra_slashes('https://host') == 'https://host'
+    assert strip_extra_slashes('https://host/') == 'https://host/'
+    assert strip_extra_slashes('https://host//') == 'https://host/'
+    assert strip_extra_slashes('https://host/path') == 'https://host/path'
+    assert strip_extra_slashes('https://host/path/') == 'https://host/path/'
+    assert strip_extra_slashes('https://host/path//') == 'https://host/path/'
+    assert strip_extra_slashes('https://host//path//') == 'https://host//path/'
+    assert strip_extra_slashes(
+        'https://host//path//////////') == 'https://host//path/'


### PR DESCRIPTION
This commit modifies the BaseService.set_service_url()
function so that it removes any trailing slashes.

Previously, a service URL containing a trailing slash
(e.g. "https://myserver.com/api/v1/") would result in a
request URL that contains two slashes between the service URL
and the operation path (e.g. "https://myserver.com/api/v1//myoperationpath"),
and some server implementations might fail to process such
a request properly.

With the changes in this commit, a request URL of
"https://myserver.com/api/v1/myoperationpath" will be used instead.