### PR TITLE
build: use bionic dist in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: python
 
 matrix:
@@ -7,23 +9,18 @@ matrix:
     - python: 3.8
     - python: 3.9
     
-dist: xenial
-
 cache: pip3
 
 before_install:
 - npm install npm@latest -g
 
 install:
-- pip3 install tox-travis
-
-before_script:
 - sudo apt-get update
 - pip3 install pypandoc
 - sudo apt-get install pandoc
 
 script:
-- tox
+- make ci
 
 before_deploy:
 - pip3 install --editable .

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,14 @@
 
 setup: deps dev_deps install_project
 
-all: setup test-unit lint
+all: upgrade_pip setup test-unit lint
+
+ci: setup test-unit lint
+
+upgrade_pip:
+	python -m pip install --upgrade pip
 
 deps:
-	python -m pip install --upgrade pip
 	python -m pip install -r requirements.txt
 
 dev_deps:


### PR DESCRIPTION
This PR fixes a recent pylint problem seen with python 3.7.1 (the default version used by the travis xenial build image) by upgrading the build up to the bionic image where python 3.7.6 is used instead.
I also took this opportunity to remove the use of tox in the travis build since it's really not needed.  Instead, we just run the "make ci" command in each of the travis build jobs (one job per python version... 3.6 - 3.9).