### PR TITLE
build: bump requests and urllib3 deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-requests>=2.20,<3.0
+requests>=2.26.0,<3.0.0
+urllib3>=1.26.0,<2.0.0
 python_dateutil>=2.5.3,<3.0.0
 PyJWT>=2.0.1,<3.0.0


### PR DESCRIPTION
This PR bumps up our requests dependency to 2.26.0, and explicitly adds a dependency on urllib3 (>= 1.26.0) due to the retry-related code in the python core.