### PR TITLE
feat: use module names for loggers

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -35,6 +35,8 @@ from .utils import (has_bad_first_or_last_char, remove_null_values,
                     cleanup_values, read_external_sources, strip_extra_slashes)
 from .version import __version__
 
+logger = logging.getLogger(__name__)
+
 # Uncomment this to enable http debugging
 # import http.client as http_client
 # http_client.HTTPConnection.debuglevel = 1
@@ -295,7 +297,7 @@ class BaseService:
         for key in reserved_keys:
             if key in kwargs:
                 del kwargs[key]
-                logging.warning('"%s" has been removed from the request', key)
+                logger.warning('"%s" has been removed from the request', key)
         try:
             response = self.http_client.request(**request,
                                                 cookies=self.jar,
@@ -320,7 +322,7 @@ class BaseService:
 
             raise ApiException(response.status_code, http_response=response)
         except requests.exceptions.SSLError:
-            logging.exception(self.ERROR_MSG_DISABLE_SSL)
+            logger.exception(self.ERROR_MSG_DISABLE_SSL)
             raise
 
     def set_enable_gzip_compression(self,

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -35,11 +35,12 @@ from .utils import (has_bad_first_or_last_char, remove_null_values,
                     cleanup_values, read_external_sources, strip_extra_slashes)
 from .version import __version__
 
-logger = logging.getLogger(__name__)
-
 # Uncomment this to enable http debugging
 # import http.client as http_client
 # http_client.HTTPConnection.debuglevel = 1
+
+
+logger = logging.getLogger(__name__)
 
 
 #pylint: disable=too-many-instance-attributes

--- a/ibm_cloud_sdk_core/token_managers/container_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/container_token_manager.py
@@ -19,6 +19,7 @@ from typing import Dict, Optional
 
 from .iam_request_based_token_manager import IAMRequestBasedTokenManager
 
+logger = logging.getLogger(__name__)
 
 class ContainerTokenManager(IAMRequestBasedTokenManager):
     """The ContainerTokenManager takes a compute resource token and performs the necessary interactions with
@@ -110,7 +111,7 @@ class ContainerTokenManager(IAMRequestBasedTokenManager):
         """
         cr_token_filename = self.cr_token_filename if self.cr_token_filename else self.DEFAULT_CR_TOKEN_FILENAME
 
-        logging.debug('Attempting to read CR token from file: %s',
+        logger.debug('Attempting to read CR token from file: %s',
                       cr_token_filename)
 
         try:

--- a/ibm_cloud_sdk_core/token_managers/container_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/container_token_manager.py
@@ -19,7 +19,9 @@ from typing import Dict, Optional
 
 from .iam_request_based_token_manager import IAMRequestBasedTokenManager
 
+
 logger = logging.getLogger(__name__)
+
 
 class ContainerTokenManager(IAMRequestBasedTokenManager):
     """The ContainerTokenManager takes a compute resource token and performs the necessary interactions with

--- a/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from .jwt_token_manager import JWTTokenManager
 
+logger = logging.getLogger(__name__)
 
 class VPCInstanceTokenManager(JWTTokenManager):
     """The VPCInstanceTokenManager retrieves an "instance identity token" and exchanges that
@@ -91,7 +92,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             'Authorization': 'Bearer ' + instance_identity_token
         }
 
-        logging.debug(
+        logger.debug(
             'Invoking VPC \'create_iam_token\' operation: %s', url)
         response = self._request(
             method='POST',
@@ -99,7 +100,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             headers=headers,
             params={'version': self.METADATA_SERVICE_VERSION},
             data=json.dumps(request_payload) if request_payload else None)
-        logging.debug('Returned from VPC \'create_iam_token\' operation."')
+        logger.debug('Returned from VPC \'create_iam_token\' operation."')
 
         return response
 
@@ -139,7 +140,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
 
         request_body = {'expires_in': 300}
 
-        logging.debug(
+        logger.debug(
             'Invoking VPC \'create_access_token\' operation: %s', url)
         response = self._request(
             method='PUT',
@@ -147,6 +148,6 @@ class VPCInstanceTokenManager(JWTTokenManager):
             headers=headers,
             params={'version': self.METADATA_SERVICE_VERSION},
             data=json.dumps(request_body))
-        logging.debug('Returned from VPC \'create_access_token\' operation."')
+        logger.debug('Returned from VPC \'create_access_token\' operation."')
 
         return response['access_token']

--- a/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
@@ -20,7 +20,9 @@ from typing import Optional
 
 from .jwt_token_manager import JWTTokenManager
 
+
 logger = logging.getLogger(__name__)
+
 
 class VPCInstanceTokenManager(JWTTokenManager):
     """The VPCInstanceTokenManager retrieves an "instance identity token" and exchanges that


### PR DESCRIPTION
Hi!

We've been using this package for around a year now and have really enjoyed how simple it makes submitting queries to the Watson API.

However, we'd like to be able to control the level of logging produced by the library. At present this is difficult since all of the modules what use logging do it via the root logger (so it's impossible to pin-point just what we are turning off).

In this MR I have used the module name for each module that employs logging. This means that clients using the package can now selecting turn logging on or off for this package. This is the behaviour that is implemented in many popular Python packages like `requests`.

Thanks, Andrew.