### PR TITLE
chore: set minimum TLS version to v1.2

### DIFF
--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -23,6 +23,7 @@ from typing import List, Union
 from urllib.parse import urlparse, parse_qs
 
 from requests.adapters import HTTPAdapter
+from urllib3.util.ssl_ import create_urllib3_context
 
 import dateutil.parser as date_parser
 
@@ -37,7 +38,9 @@ class SSLHTTPAdapter(HTTPAdapter):
     def init_poolmanager(self, connections, maxsize, block):
         """Extends the parent's method by adding minimum SSL version to the args.
         """
-        super().init_poolmanager(connections, maxsize, block, ssl_minimum_version=ssl.TLSVersion.TLSv1_2)
+        ssl_context = create_urllib3_context()
+        ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+        super().init_poolmanager(connections, maxsize, block, ssl_context=ssl_context)
 
 
 def has_bad_first_or_last_char(val: str) -> bool:

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -16,12 +16,28 @@
 # from ibm_cloud_sdk_core.authenticators import Authenticator
 import datetime
 import json as json_import
+import ssl
 from os import getenv, environ, getcwd
 from os.path import isfile, join, expanduser
 from typing import List, Union
 from urllib.parse import urlparse, parse_qs
 
+from requests.adapters import HTTPAdapter
+
 import dateutil.parser as date_parser
+
+
+class SSLHTTPAdapter(HTTPAdapter):
+    """Wraps the original HTTP adapter and adds additional SSL context.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    #pylint: disable=arguments-differ
+    def init_poolmanager(self, connections, maxsize, block):
+        """Extends the parent's method by adding minimum SSL version to the args.
+        """
+        super().init_poolmanager(connections, maxsize, block, ssl_minimum_version=ssl.TLSVersion.TLSv1_2)
 
 
 def has_bad_first_or_last_char(val: str) -> bool:

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -929,5 +929,6 @@ def test_configure_service_error():
 def test_min_ssl_version():
     service = AnyServiceV1('2022-03-08', authenticator=NoAuthAuthenticator())
     adapter = service.http_client.get_adapter('https://')
-    poolmanager = adapter.poolmanager
-    assert poolmanager.connection_pool_kw.get('ssl_minimum_version', None) == ssl.TLSVersion.TLSv1_2
+    ssl_context = adapter.poolmanager.connection_pool_kw.get('ssl_context', None)
+    assert ssl_context is not None
+    assert ssl_context.minimum_version == ssl.TLSVersion.TLSv1_2

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -3,6 +3,7 @@
 import gzip
 import json
 import os
+import ssl
 import tempfile
 import time
 from shutil import copyfile
@@ -923,3 +924,10 @@ def test_configure_service_error():
     with pytest.raises(ValueError) as err:
         service.configure_service(None)
     assert str(err.value) == 'Service_name must be of type string.'
+
+
+def test_min_ssl_version():
+    service = AnyServiceV1('2022-03-08', authenticator=NoAuthAuthenticator())
+    adapter = service.http_client.get_adapter('https://')
+    poolmanager = adapter.poolmanager
+    assert poolmanager.connection_pool_kw.get('ssl_minimum_version', None) == ssl.TLSVersion.TLSv1_2


### PR DESCRIPTION
This PR introduces a custom HTTP adapter that wraps the original one
and adds SSL context, that sets the minimum TLS version required to v1.2.