### PR TITLE
fix: avoid warning when custom headers are used

### DIFF
--- a/ibm_cloud_sdk_core/authenticators/authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/authenticator.py
@@ -52,7 +52,6 @@ class Authenticator(ABC):
         """
         pass
 
-    # pylint: disable=R0201
     def authentication_type(self) -> str:
         """Returns the authenticator's type.  This method should be overridden by each authenticator implementation."""
         return Authenticator.AUTHTYPE_UNKNOWN

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -298,10 +298,12 @@ class BaseService:
 
         # Remove the keys we set manually, don't let the user to overwrite these.
         reserved_keys = ['method', 'url', 'headers', 'params', 'cookies']
+        silent_keys = ['headers']
         for key in reserved_keys:
             if key in kwargs:
                 del kwargs[key]
-                logger.warning('"%s" has been removed from the request', key)
+                if key not in silent_keys:
+                    logger.warning('"%s" has been removed from the request', key)
         try:
             response = self.http_client.request(**request,
                                                 cookies=self.jar,

--- a/test/test_api_exception.py
+++ b/test/test_api_exception.py
@@ -70,4 +70,4 @@ def test_api_exception():
     mock_response = requests.get('https://test-for-text.com')
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'plain text error'
-    assert exception.__str__() == 'Error: plain text error, Code: 500 , X-global-transaction-id: xx'
+    assert str(exception) == 'Error: plain text error, Code: 500 , X-global-transaction-id: xx'

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -690,12 +690,12 @@ def test_user_agent_header():
         'user-agent': 'my_user_agent'
     })
     response = service.send(prepped)
-    assert response.get_result().request.headers.__getitem__(
+    assert response.get_result().request.headers.get(
         'user-agent') == 'my_user_agent'
 
     prepped = service.prepare_request('GET', url='', headers=None)
     response = service.send(prepped)
-    assert response.get_result().request.headers.__getitem__(
+    assert response.get_result().request.headers.get(
         'user-agent') == user_agent_header['User-Agent']
 
 
@@ -715,14 +715,13 @@ def test_reserved_keys(caplog):
         url='localhost',
         cookies=None,
         hooks={'response': []})
-    assert response.get_result().request.headers.__getitem__('key') == 'OK'
+    assert response.get_result().request.headers.get('key') == 'OK'
     assert response.get_result().request.url == 'https://gateway.watsonplatform.net/test/api'
     assert response.get_result().request.method == 'GET'
     assert response.get_result().request.hooks == {'response': []}
     assert caplog.record_tuples[0][2] == '"method" has been removed from the request'
     assert caplog.record_tuples[1][2] == '"url" has been removed from the request'
-    assert caplog.record_tuples[2][2] == '"headers" has been removed from the request'
-    assert caplog.record_tuples[3][2] == '"cookies" has been removed from the request'
+    assert caplog.record_tuples[2][2] == '"cookies" has been removed from the request'
 
 
 @responses.activate

--- a/test/test_detailed_response.py
+++ b/test/test_detailed_response.py
@@ -29,10 +29,10 @@ def test_detailed_response_dict():
     assert detailed_response.get_headers() == {'Content-Type': 'application/json'}
     assert detailed_response.get_status_code() == 200
 
-    response_str = clean(detailed_response.__str__())
-    assert clean(detailed_response.get_result().__str__()) in response_str
-    #assert clean(detailed_response.get_headers().__str__()) in response_str
-    assert clean(detailed_response.get_status_code().__str__()) in response_str
+    response_str = clean(str(detailed_response))
+    assert clean(str(detailed_response.get_result())) in response_str
+    #assert clean(str(detailed_response.get_headers())) in response_str
+    assert clean(str(detailed_response.get_status_code())) in response_str
 
 
 @responses.activate
@@ -51,7 +51,7 @@ def test_detailed_response_list():
     assert detailed_response.get_headers() == {'Content-Type': 'application/json'}
     assert detailed_response.get_status_code() == 200
 
-    response_str = clean(detailed_response.__str__())
-    assert clean(detailed_response.get_result().__str__()) in response_str
-    #assert clean(detailed_response.get_headers().__str__()) in response_str
-    assert clean(detailed_response.get_status_code().__str__()) in response_str
+    response_str = clean(str(detailed_response))
+    assert clean(str(detailed_response.get_result())) in response_str
+    #assert clean(str(detailed_response.get_headers())) in response_str
+    assert clean(str(detailed_response.get_status_code())) in response_str


### PR DESCRIPTION
Fixes: arf/planning-sdk-squad#3250

This PR avoids a warning being logged when the 'headers' key is removed from kwargs by the BaseService.send() method.