### PR TITLE
build: used fixed version of setuptools for Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 - sudo apt-get update
 - pip3 install pypandoc
 - sudo apt-get install pandoc
+- pip3 install setuptools=="60.8.2"
 
 script:
 - make ci
@@ -39,7 +40,6 @@ deploy:
       python: '3.7'
       branch: main
   - provider: pypi
-    setuptools_version: "60.8.2"
     user: $PYPI_USER
     password: $PYPI_TOKEN
     repository: https://upload.pypi.org/legacy


### PR DESCRIPTION
This commit fixes the version of the `setuptools` package for Python 3.7
and 3.8 builds to address build issues.