### PR TITLE
feat(CP4D Authentication): add ssl verification for self-signed certificates

### DIFF
--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -59,14 +59,15 @@ class CloudPakForDataAuthenticator(Authenticator):
                  apikey: str = None,
                  disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
-                 proxies: Optional[Dict[str, str]] = None) -> None:
+                 proxies: Optional[Dict[str, str]] = None,
+                 verify: Optional[str] = None) -> None:
         # Check the type of `disable_ssl_verification`. Must be a bool.
         if not isinstance(disable_ssl_verification, bool):
             raise TypeError('disable_ssl_verification must be a bool')
 
         self.token_manager = CP4DTokenManager(
             username=username, password=password, apikey=apikey, url=url,
-            disable_ssl_verification=disable_ssl_verification, headers=headers, proxies=proxies)
+            disable_ssl_verification=disable_ssl_verification, headers=headers, proxies=proxies, verify=verify)
 
         self.validate()
 

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -42,6 +42,7 @@ class CloudPakForDataAuthenticator(Authenticator):
         proxies: Dictionary for mapping request protocol to proxy URL.
         proxies.http (optional): The proxy endpoint to use for HTTP requests.
         proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+        verify (optional): The path to the certificate to use for HTTPS requests.
 
     Attributes:
         token_manager (CP4DTokenManager): Retrieves and manages CP4D tokens from the endpoint specified by the url.

--- a/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
@@ -57,9 +57,11 @@ class CP4DTokenManager(JWTTokenManager):
                  apikey: str = None,
                  disable_ssl_verification: bool = False,
                  headers: Optional[Dict[str, str]] = None,
-                 proxies: Optional[Dict[str, str]] = None) -> None:
+                 proxies: Optional[Dict[str, str]] = None,
+                 verify: Optional[str] = None) -> None:
         self.username = username
         self.password = password
+        self.verify = verify
         if url and not self.VALIDATE_AUTH_PATH in url:
             url = url + '/v1/authorize'
         self.apikey = apikey
@@ -83,7 +85,8 @@ class CP4DTokenManager(JWTTokenManager):
                 "password": self.password,
                 "api_key": self.apikey
             }),
-            proxies=self.proxies)
+            proxies=self.proxies,
+            verify=self.verify)
         return response
 
     def set_headers(self, headers: Dict[str, str]) -> None:

--- a/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
@@ -36,6 +36,7 @@ class CP4DTokenManager(JWTTokenManager):
         proxies: Proxies to use for making request. Defaults to None.
         proxies.http (optional): The proxy endpoint to use for HTTP requests.
         proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+        verify (optional): The path to the certificate to use for HTTPS requests.
 
     Attributes:
         username (str): The username for authentication.
@@ -45,6 +46,7 @@ class CP4DTokenManager(JWTTokenManager):
         proxies (dict): Proxies to use for making token requests.
         proxies.http (str): The proxy endpoint to use for HTTP requests.
         proxies.https (str): The proxy endpoint to use for HTTPS requests.
+        verify (str): The path to the certificate to use for HTTPS requests.
     """
     TOKEN_NAME = 'token'
     VALIDATE_AUTH_PATH = '/v1/authorize'


### PR DESCRIPTION
These modifications allow the user to have a self-signed certificate in the SSL verification process when authenticating to an STT instance on CP4D.

The `verify` attribute is used by the [requests python module](https://pypi.org/project/requests/) to indicate the path to a custom CA Bundle ([resquests documentation](https://requests.readthedocs.io/en/latest/api/?highlight=verify)).

With these changes, it wont be necessary to disable ssl verification anymore when using a self-signed certificate with STT on CP4D.