### PR TITLE
fix: detect JSON unmarshal errors in responses

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -25,6 +25,7 @@ from urllib3.util.retry import Retry
 
 import requests
 from requests.structures import CaseInsensitiveDict
+from requests.exceptions import JSONDecodeError
 
 from ibm_cloud_sdk_core.authenticators import Authenticator
 from .api_exception import ApiException
@@ -32,6 +33,7 @@ from .detailed_response import DetailedResponse
 from .token_managers.token_manager import TokenManager
 from .utils import (
     has_bad_first_or_last_char,
+    is_json_mimetype,
     remove_null_values,
     cleanup_values,
     read_external_sources,
@@ -310,21 +312,32 @@ class BaseService:
         try:
             response = self.http_client.request(**request, cookies=self.jar, **kwargs)
 
+            # Process a "success" response.
             if 200 <= response.status_code <= 299:
                 if response.status_code == 204 or request['method'] == 'HEAD':
-                    # There is no body content for a HEAD request or a 204 response
+                    # There is no body content for a HEAD response or a 204 response.
                     result = None
                 elif stream_response:
                     result = response
                 elif not response.text:
                     result = None
-                else:
+                elif is_json_mimetype(response.headers['Content-Type']):
+                    # If this is a JSON response, then try to unmarshal it.
                     try:
                         result = response.json()
-                    except:
-                        result = response
+                    except JSONDecodeError as err:
+                        caused_by = str(err)
+                        logger.error(
+                            'Expected JSON content in response body, but a parsing error occurred:\n%s', caused_by
+                        )
+                        raise
+                else:
+                    # Non-JSON response, just use response body as-is.
+                    result = response
+
                 return DetailedResponse(response=result, headers=response.headers, status_code=response.status_code)
 
+            # Received error status code from server, raise an APIException.
             raise ApiException(response.status_code, http_response=response)
         except requests.exceptions.SSLError:
             logger.exception(self.ERROR_MSG_DISABLE_SSL)

--- a/ibm_cloud_sdk_core/detailed_response.py
+++ b/ibm_cloud_sdk_core/detailed_response.py
@@ -26,7 +26,7 @@ class DetailedResponse:
     Keyword Args:
         response: The response to the service request, defaults to None.
         headers: The headers of the response, defaults to None.
-        status_code: The status code of there response, defaults to None.
+        status_code: The status code of the response, defaults to None.
 
     Attributes:
         result (dict, requests.Response, None): The response to the service request.

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -16,6 +16,7 @@
 # from ibm_cloud_sdk_core.authenticators import Authenticator
 import datetime
 import json as json_import
+import re
 import ssl
 from os import getenv, environ, getcwd
 from os.path import isfile, join, expanduser
@@ -395,3 +396,19 @@ def __read_from_vcap_services(service_name: str) -> dict:
                 new_vcap_creds['APIKEY'] = vcap_service_credentials.get('apikey')
                 vcap_service_credentials = new_vcap_creds
     return vcap_service_credentials
+
+
+# A regex that matches an "application/json" mimetype.
+json_mimetype_pattern = re.compile('^application/json(\\s*;.*)?$')
+
+
+def is_json_mimetype(mimetype: str) -> bool:
+    """Returns true iff 'mimetype' is a JSON-like mimetype.
+
+    Args:
+        mimetype: The mimetype to check.
+
+    Returns:
+        true if mimetype is a JSON-line mimetype, false otherwise.
+    """
+    return mimetype is not None and json_mimetype_pattern.match(mimetype) is not None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -28,7 +28,7 @@ from ibm_cloud_sdk_core import convert_model, convert_list
 from ibm_cloud_sdk_core import get_query_param
 from ibm_cloud_sdk_core import read_external_sources
 from ibm_cloud_sdk_core.authenticators import Authenticator, BasicAuthenticator, IAMAuthenticator
-from ibm_cloud_sdk_core.utils import strip_extra_slashes
+from ibm_cloud_sdk_core.utils import strip_extra_slashes, is_json_mimetype
 
 
 def datetime_test(datestr: str, expected: str):
@@ -605,3 +605,15 @@ def test_strip_extra_slashes():
     assert strip_extra_slashes('https://host/path//') == 'https://host/path/'
     assert strip_extra_slashes('https://host//path//') == 'https://host//path/'
     assert strip_extra_slashes('https://host//path//////////') == 'https://host//path/'
+
+
+def test_is_json_mimetype():
+    assert is_json_mimetype(None) is False
+    assert is_json_mimetype('') is False
+    assert is_json_mimetype('application/octet-stream') is False
+    assert is_json_mimetype('ApPlIcAtION/JsoN') is False
+    assert is_json_mimetype('applicaiton/json; charset=utf8') is False
+    assert is_json_mimetype('fooapplication/json; charset=utf8; foo=bar') is False
+
+    assert is_json_mimetype('application/json') is True
+    assert is_json_mimetype('application/json; charset=utf8') is True


### PR DESCRIPTION
This commit fixes BaseService.send() so that it
will now  detect a JSON parsing error when processing a success (2xx) response.
If, in fact, a JSON parsing error occurs while
trying to process a JSON response body,
then a requests.exceptions.JSONDecodeError
is raised and propagated back to the caller.