### PR TITLE
feat: return response text as result intead of the whole object

### DIFF
--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -40,6 +40,7 @@ from .utils import (
     read_external_sources,
     strip_extra_slashes,
     SSLHTTPAdapter,
+    TextResult,
 )
 from .version import __version__
 
@@ -330,7 +331,7 @@ class BaseService:
         elif stream_response:
             result = response
         elif is_text_mimetype(content_type):
-            result = response.text
+            result = TextResult(response)
         elif is_json_mimetype(content_type):
             # If this is a JSON response, then try to unmarshal it.
             try:

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -34,6 +34,7 @@ from .token_managers.token_manager import TokenManager
 from .utils import (
     has_bad_first_or_last_char,
     is_json_mimetype,
+    is_text_mimetype,
     remove_null_values,
     cleanup_values,
     read_external_sources,
@@ -311,6 +312,7 @@ class BaseService:
                     logger.warning('"%s" has been removed from the request', key)
         try:
             response = self.http_client.request(**request, cookies=self.jar, **kwargs)
+            content_type = response.headers.get('Content-Type')
 
             # Process a "success" response.
             if 200 <= response.status_code <= 299:
@@ -321,7 +323,9 @@ class BaseService:
                     result = response
                 elif not response.text:
                     result = None
-                elif is_json_mimetype(response.headers.get('Content-Type')):
+                elif is_text_mimetype(content_type):
+                    result = response.text
+                elif is_json_mimetype(content_type):
                     # If this is a JSON response, then try to unmarshal it.
                     try:
                         result = response.json(strict=False)

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -23,6 +23,7 @@ from os.path import isfile, join, expanduser
 from typing import List, Union
 from urllib.parse import urlparse, parse_qs
 
+from requests import Response
 from requests.adapters import HTTPAdapter
 from urllib3.util.ssl_ import create_urllib3_context
 
@@ -424,3 +425,21 @@ def is_text_mimetype(mimetype: str) -> bool:
         true if mimetype is a text-like mimetype, false otherwise.
     """
     return mimetype is not None and mimetype.startswith('text/')
+
+
+class TextResult(Response):
+    """Helper class to add better support for text responses.
+
+    Keyword Args:
+        response: The response to the service request.
+    """
+
+    def __init__(self, response: Response) -> None:
+        # Init parent.
+        super().__init__()
+        self.__dict__.update(response.__dict__)
+        # Overrides parent's `__repr__` method.
+        self.__repr__ = self.__repr__
+
+    def __repr__(self) -> str:
+        return self.text

--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -409,6 +409,18 @@ def is_json_mimetype(mimetype: str) -> bool:
         mimetype: The mimetype to check.
 
     Returns:
-        true if mimetype is a JSON-line mimetype, false otherwise.
+        true if mimetype is a JSON-like mimetype, false otherwise.
     """
     return mimetype is not None and json_mimetype_pattern.match(mimetype) is not None
+
+
+def is_text_mimetype(mimetype: str) -> bool:
+    """Returns true if 'mimetype' is a text-like mimetype, false otherwise.
+
+    Args:
+        mimetype: The mimetype to check.
+
+    Returns:
+        true if mimetype is a text-like mimetype, false otherwise.
+    """
+    return mimetype is not None and mimetype.startswith('text/')

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -432,9 +432,7 @@ def test_request_success_nonjson():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
     prepped = service.prepare_request('GET', url='')
     detailed_response = service.send(prepped)
-    # It's odd that we have to call ".text" to get the string value
-    # (see issue 3557)
-    assert detailed_response.get_result().text == '<h1>Hola, amigo!</h1>'
+    assert detailed_response.get_result() == '<h1>Hola, amigo!</h1>'
 
 
 @responses.activate
@@ -735,7 +733,13 @@ def test_user_agent_header():
     assert user_agent_header is not None
     assert user_agent_header['User-Agent'] is not None
 
-    responses.add(responses.GET, 'https://gateway.watsonplatform.net/test/api', status=200, body='some text')
+    responses.add(
+        responses.GET,
+        'https://gateway.watsonplatform.net/test/api',
+        status=200,
+        body='<feed>something new<feed>',
+        content_type='application/atom-xml',
+    )
     prepped = service.prepare_request('GET', url='', headers={'user-agent': 'my_user_agent'})
     response = service.send(prepped)
     assert response.get_result().request.headers.get('user-agent') == 'my_user_agent'
@@ -748,7 +752,13 @@ def test_user_agent_header():
 @responses.activate
 def test_reserved_keys(caplog):
     service = AnyServiceV1('2021-07-02', authenticator=NoAuthAuthenticator())
-    responses.add(responses.GET, 'https://gateway.watsonplatform.net/test/api', status=200, body='some text')
+    responses.add(
+        responses.GET,
+        'https://gateway.watsonplatform.net/test/api',
+        status=200,
+        body='<feed>something new<feed>',
+        content_type='application/atom-xml',
+    )
     prepped = service.prepare_request('GET', url='', headers={'key': 'OK'})
     response = service.send(
         prepped, headers={'key': 'bad'}, method='POST', url='localhost', cookies=None, hooks={'response': []}

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -432,7 +432,9 @@ def test_request_success_nonjson():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
     prepped = service.prepare_request('GET', url='')
     detailed_response = service.send(prepped)
-    assert detailed_response.get_result() == '<h1>Hola, amigo!</h1>'
+    # It's odd that we have to call ".text" to get the string value
+    # (see issue 3557)
+    assert detailed_response.get_result().text == '<h1>Hola, amigo!</h1>'
 
 
 @responses.activate
@@ -733,13 +735,7 @@ def test_user_agent_header():
     assert user_agent_header is not None
     assert user_agent_header['User-Agent'] is not None
 
-    responses.add(
-        responses.GET,
-        'https://gateway.watsonplatform.net/test/api',
-        status=200,
-        body='<feed>something new<feed>',
-        content_type='application/atom-xml',
-    )
+    responses.add(responses.GET, 'https://gateway.watsonplatform.net/test/api', status=200, body='some text')
     prepped = service.prepare_request('GET', url='', headers={'user-agent': 'my_user_agent'})
     response = service.send(prepped)
     assert response.get_result().request.headers.get('user-agent') == 'my_user_agent'
@@ -752,13 +748,7 @@ def test_user_agent_header():
 @responses.activate
 def test_reserved_keys(caplog):
     service = AnyServiceV1('2021-07-02', authenticator=NoAuthAuthenticator())
-    responses.add(
-        responses.GET,
-        'https://gateway.watsonplatform.net/test/api',
-        status=200,
-        body='<feed>something new<feed>',
-        content_type='application/atom-xml',
-    )
+    responses.add(responses.GET, 'https://gateway.watsonplatform.net/test/api', status=200, body='some text')
     prepped = service.prepare_request('GET', url='', headers={'key': 'OK'})
     response = service.send(
         prepped, headers={'key': 'bad'}, method='POST', url='localhost', cookies=None, hooks={'response': []}

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -432,8 +432,8 @@ def test_request_success_nonjson():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
     prepped = service.prepare_request('GET', url='')
     detailed_response = service.send(prepped)
-    # It's odd that we have to call ".text" to get the string value
-    # (see issue 3557)
+    assert repr(detailed_response.get_result()) == '<h1>Hola, amigo!</h1>'
+    assert str(detailed_response.get_result()) == '<h1>Hola, amigo!</h1>'
     assert detailed_response.get_result().text == '<h1>Hola, amigo!</h1>'
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -28,7 +28,7 @@ from ibm_cloud_sdk_core import convert_model, convert_list
 from ibm_cloud_sdk_core import get_query_param
 from ibm_cloud_sdk_core import read_external_sources
 from ibm_cloud_sdk_core.authenticators import Authenticator, BasicAuthenticator, IAMAuthenticator
-from ibm_cloud_sdk_core.utils import strip_extra_slashes, is_json_mimetype
+from ibm_cloud_sdk_core.utils import strip_extra_slashes, is_json_mimetype, is_text_mimetype
 
 
 def datetime_test(datestr: str, expected: str):
@@ -617,3 +617,13 @@ def test_is_json_mimetype():
 
     assert is_json_mimetype('application/json') is True
     assert is_json_mimetype('application/json; charset=utf8') is True
+
+
+def test_is_text_mimetype():
+    assert is_text_mimetype(None) is False
+    assert is_text_mimetype('') is False
+    assert is_text_mimetype('application/octet-stream') is False
+    assert is_text_mimetype('Text/Plain') is False
+
+    assert is_text_mimetype('text/plain') is True
+    assert is_text_mimetype('text/html') is True


### PR DESCRIPTION
In case of text responses like `text/plain`, `text/html`, etc... the `send`
method returns the whole response object as the result in the 
`DetailedResponse` object. This PR changes this behavior so that
the `send` method will return the response text from the body as string.
It means it can be accessed directly from the response by calling
`response.get_result()`.