### PR TITLE
fix(ContainerAuthenticator): add sa-token as default CR token filename

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -223,7 +223,8 @@ The IAM access token is added to each outbound request in the `Authorization` he
 ### Properties
 
 - cr_token_filename: (optional) The name of the file containing the injected CR token value.
-If not specified, then `/var/run/secrets/tokens/vault-token` is used as the default value.
+If not specified, then the authenticator will first try `/var/run/secrets/tokens/vault-token`
+and then `/var/run/secrets/tokens/sa-token` as the default value (first file found is used).
 The application must have `read` permissions on the file containing the CR token value.
 
 - iam_profile_name: (optional) The name of the linked trusted IAM profile to be used when obtaining the

--- a/test/test_container_token_manager.py
+++ b/test/test_container_token_manager.py
@@ -151,7 +151,7 @@ def test_retrieve_cr_token_fail():
 
     assert (
         str(err.value)
-        == 'Unable to retrieve the CR token value from file bogus-cr-token-file: [Errno 2] No such file or directory: \'bogus-cr-token-file\''
+        == 'Unable to retrieve the CR token: Error reading CR token from file bogus-cr-token-file: [Errno 2] No such file or directory: \'bogus-cr-token-file\''
     )
 
 
@@ -236,7 +236,7 @@ def test_authenticate_fail_no_cr_token():
 
     assert (
         str(err.value)
-        == 'Unable to retrieve the CR token value from file bogus-cr-token-file: [Errno 2] No such file or directory: \'bogus-cr-token-file\''
+        == 'Unable to retrieve the CR token: Error reading CR token from file bogus-cr-token-file: [Errno 2] No such file or directory: \'bogus-cr-token-file\''
     )
 
 


### PR DESCRIPTION
This commit adds support for a second default CR token filename. If the user doesn't specify a CR token filename, the authenticator will first try '/var/run/secrets/tokens/vault-token', and then '/var/run/secrets/tokens/sa-token' in that order.