### PR TITLE
feat(MCSPAuthenticator): add new authenticator for Multi-Cloud Saas Platform

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-03-23T17:37:09Z",
+  "generated_at": "2023-11-10T17:28:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
         "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 64,
+        "line_number": 65,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -78,7 +78,7 @@
         "hashed_secret": "98635b2eaa2379f28cd6d72a38299f286b81b459",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 385,
+        "line_number": 387,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -86,7 +86,7 @@
         "hashed_secret": "47fcf185ee7e15fe05cae31fbe9e4ebe4a06a40d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 416,
+        "line_number": 482,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -157,6 +157,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 1,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "resources/ibm-credentials-mcsp.env": [
+      {
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -341,12 +351,64 @@
         "verified_result": null
       }
     ],
+    "test/test_mcsp_authenticator.py": [
+      {
+        "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 91,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 147,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "test/test_mcsp_token_manager.py": [
+      {
+        "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "ace1a5bf229c3af3f699369c6f2fa1a628692ab8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 60,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
     "test/test_utils.py": [
       {
         "hashed_secret": "34a0a47a51d5bf739df0214450385e29ee7e9847",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 423,
+        "line_number": 435,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 446,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -354,7 +416,7 @@
         "hashed_secret": "2863fa4b5510c46afc2bd2998dfbc0cf3d6df032",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 503,
+        "line_number": 528,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -362,7 +424,7 @@
         "hashed_secret": "b9cad336062c0dc3bb30145b1a6697fccfe755a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 564,
+        "line_number": 589,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -378,7 +440,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.57.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/Authentication.md
+++ b/Authentication.md
@@ -6,6 +6,7 @@ The python-sdk-core project supports the following types of authentication:
 - Container Authentication
 - VPC Instance Authentication
 - Cloud Pak for Data Authentication
+- Multi-Cloud Saas Platform (MCSP) Authentication
 - No Authentication (for testing)
 
 The SDK user configures the appropriate type of authentication for use with service instances.
@@ -426,6 +427,71 @@ service = ExampleServiceV1.new_instance(service_name='example_service')
 
 # 'service' can now be used to invoke operations.
 ```
+
+
+## Multi-Cloud Saas Platform (MCSP) Authentication
+The `MCSPAuthenticator` can be used in scenarios where an application needs to
+interact with an IBM Cloud service that has been deployed to a non-IBM Cloud environment (e.g. AWS).
+It accepts a user-supplied apikey and performs the necessary interactions with the
+Multi-Cloud Saas Platform token service to obtain a suitable MCSP access token (a bearer token)
+for the specified apikey.
+The authenticator will also obtain a new bearer token when the current token expires.
+The bearer token is then added to each outbound request in the `Authorization` header in the
+form:
+```
+   Authorization: Bearer <bearer-token>
+```
+
+### Properties
+
+- apikey: (required) the apikey to be used to obtain an MCSP access token.
+
+- url: (required) The URL representing the MCSP token service endpoint's base URL string. Do not include the
+operation path (e.g. `/siusermgr/api/1.0/apikeys/token`) as part of this property's value.
+
+- disable_ssl_verification: (optional) A flag that indicates whether verificaton of the server's SSL
+certificate should be disabled or not. The default value is `false`.
+
+- headers: (optional) A set of key/value pairs that will be sent as HTTP headers in requests
+made to the MCSP token service.
+
+### Usage Notes
+- When constructing an MCSPAuthenticator instance, you must specify the apikey and url properties.
+
+- The authenticator will use the token server's `POST /siusermgr/api/1.0/apikeys/token` operation to
+exchange the user-supplied apikey for an MCSP access token (the bearer token).
+
+### Programming example
+```python
+from ibm_cloud_sdk_core.authenticators import MCSPAuthenticator
+from <sdk-package-name>.example_service_v1 import *
+
+# Create the authenticator.
+authenticator = MCSPAuthenticator(apikey='myapikey', url='https://example.mcsp.token-exchange.com')
+
+# Construct the service instance.
+service = ExampleServiceV1(authenticator=authenticator)
+
+# 'service' can now be used to invoke operations.
+```
+
+### Configuration example
+External configuration:
+```
+export EXAMPLE_SERVICE_AUTH_TYPE=mcsp
+export EXAMPLE_SERVICE_APIKEY=myapikey
+export EXAMPLE_SERVICE_AUTH_URL=https://example.mcsp.token-exchange.com
+```
+Application code:
+```python
+from <sdk-package-name>.example_service_v1 import *
+
+# Construct the service instance.
+service = ExampleServiceV1.new_instance(service_name='example_service')
+
+# 'service' can now be used to invoke operations.
+```
+
 
 ## No Auth Authentication
 The `NoAuthAuthenticator` is a placeholder authenticator which performs no actual authentication function.

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 # to be ready for development work in the local sandbox.
 # example: "make setup"
 
+PYTHON=python3
+LINT_DIRS=ibm_cloud_sdk_core test test_integration
+
 setup: deps dev_deps install_project
 
 all: upgrade_pip setup test-unit lint
@@ -9,22 +12,23 @@ all: upgrade_pip setup test-unit lint
 ci: setup test-unit lint
 
 upgrade_pip:
-	python -m pip install --upgrade pip
+	${PYTHON} -m pip install --upgrade pip
 
 deps:
-	python -m pip install -r requirements.txt
+	${PYTHON} -m pip install -r requirements.txt
 
 dev_deps:
-	python -m pip install -r requirements-dev.txt
+	${PYTHON} -m pip install -r requirements-dev.txt
 
 install_project:
-	python -m pip install -e .
+	${PYTHON} -m pip install -e .
 
 test-unit:
-	python -m pytest --cov=ibm_cloud_sdk_core test
+	${PYTHON} -m pytest --cov=ibm_cloud_sdk_core test
 
 lint:
-	./pylint.sh && black --check .
+	${PYTHON} -m pylint ${LINT_DIRS}
+	black --check ${LINT_DIRS}
 
 lint-fix:
-	black .
+	black ${LINT_DIRS}

--- a/ibm_cloud_sdk_core/__init__.py
+++ b/ibm_cloud_sdk_core/__init__.py
@@ -43,6 +43,7 @@ from .token_managers.jwt_token_manager import JWTTokenManager
 from .token_managers.cp4d_token_manager import CP4DTokenManager
 from .token_managers.container_token_manager import ContainerTokenManager
 from .token_managers.vpc_instance_token_manager import VPCInstanceTokenManager
+from .token_managers.mcsp_token_manager import MCSPTokenManager
 from .api_exception import ApiException
 from .utils import datetime_to_string, string_to_datetime, read_external_sources
 from .utils import datetime_to_string_list, string_to_datetime_list

--- a/ibm_cloud_sdk_core/authenticators/__init__.py
+++ b/ibm_cloud_sdk_core/authenticators/__init__.py
@@ -41,3 +41,4 @@ from .cp4d_authenticator import CloudPakForDataAuthenticator
 from .iam_authenticator import IAMAuthenticator
 from .vpc_instance_authenticator import VPCInstanceAuthenticator
 from .no_auth_authenticator import NoAuthAuthenticator
+from .mcsp_authenticator import MCSPAuthenticator

--- a/ibm_cloud_sdk_core/authenticators/authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/authenticator.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2019 IBM All Rights Reserved.
+# Copyright 2019, 2023 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ class Authenticator(ABC):
     AUTHTYPE_CP4D = 'cp4d'
     AUTHTYPE_VPC = 'vpc'
     AUTHTYPE_NOAUTH = 'noAuth'
+    AUTHTYPE_MCSP = 'mcsp'
     AUTHTYPE_UNKNOWN = 'unknown'
 
     @abstractmethod

--- a/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
@@ -76,7 +76,7 @@ class BasicAuthenticator(Authenticator):
             Authorization: Basic <encoded username and password>
 
         Args:
-            req: The request to add basic auth information too. Must contain a key to a dictionary
+            req: The request to add basic auth information to. Must contain a key to a dictionary
             called headers.
         """
         headers = req.get('headers')

--- a/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
@@ -61,7 +61,7 @@ class BearerTokenAuthenticator(Authenticator):
             Authorization: Bearer <bearer-token>
 
         Args:
-            req: The request to add bearer authentication information too. Must contain a key to a dictionary
+            req: The request to add bearer authentication information to. Must contain a key to a dictionary
             called headers.
         """
         headers = req.get('headers')

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -127,7 +127,7 @@ class CloudPakForDataAuthenticator(Authenticator):
             Authorization: Bearer <bearer-token>
 
         Args:
-            req:  The request to add CP4D authentication information too. Must contain a key to a dictionary
+            req:  The request to add CP4D authentication information to. Must contain a key to a dictionary
             called headers.
         """
         headers = req.get('headers')

--- a/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
@@ -54,7 +54,7 @@ class IAMRequestBasedAuthenticator(Authenticator):
             Authorization: Bearer <bearer-token>
 
         Args:
-            req: The request to add IAM authentication information too. Must contain a key to a dictionary
+            req: The request to add IAM authentication information to. Must contain a key to a dictionary
             called headers.
         """
         headers = req.get('headers')

--- a/ibm_cloud_sdk_core/authenticators/mcsp_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/mcsp_authenticator.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+
+# Copyright 2023 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Optional
+
+from requests import Request
+
+from .authenticator import Authenticator
+from ..token_managers.mcsp_token_manager import MCSPTokenManager
+
+
+class MCSPAuthenticator(Authenticator):
+    """The MCSPAuthenticator uses an apikey to obtain an access token from the MCSP token server.
+    When the access token expires, a new access token is obtained from the token server.
+    The access token will be added to outbound requests via the Authorization header
+    of the form:    "Authorization: Bearer <access-token>"
+
+    Keyword Args:
+        url: The base endpoint URL for the MCSP token service [required].
+        apikey: The API key used to obtain an access token [required].
+        disable_ssl_verification:  A flag that indicates whether verification of the server's SSL
+            certificate should be disabled or not. Defaults to False.
+        headers: Default headers to be sent with every MCSP token request. Defaults to None.
+        proxies: Dictionary for mapping request protocol to proxy URL.
+        proxies.http (optional): The proxy endpoint to use for HTTP requests.
+        proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+
+    Attributes:
+        token_manager (MCSPTokenManager): Retrieves and manages MCSP tokens from the endpoint specified by the url.
+
+    Raises:
+        TypeError: The `disable_ssl_verification` is not a bool.
+        ValueError: The apikey and/or url are not valid for MCSP token exchange requests.
+    """
+
+    def __init__(
+        self,
+        apikey: str,
+        url: str,
+        *,
+        disable_ssl_verification: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        proxies: Optional[Dict[str, str]] = None,
+    ) -> None:
+        # Check the type of `disable_ssl_verification`. Must be a bool.
+        if not isinstance(disable_ssl_verification, bool):
+            raise TypeError('disable_ssl_verification must be a bool')
+
+        self.token_manager = MCSPTokenManager(
+            apikey=apikey,
+            url=url,
+            disable_ssl_verification=disable_ssl_verification,
+            headers=headers,
+            proxies=proxies,
+        )
+
+        self.validate()
+
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('mcsp')."""
+        return Authenticator.AUTHTYPE_MCSP
+
+    def validate(self) -> None:
+        """Validate apikey and url for token requests.
+
+        Raises:
+            ValueError: The apikey and/or url are not valid for token requests.
+        """
+        if self.token_manager.apikey is None:
+            raise ValueError('The apikey shouldn\'t be None.')
+
+        if self.token_manager.url is None:
+            raise ValueError('The url shouldn\'t be None.')
+
+    def authenticate(self, req: Request) -> None:
+        """Adds MCSP authentication information to the request.
+
+        The MCSP bearer token will be added to the request's headers in the form:
+            Authorization: Bearer <bearer-token>
+
+        Args:
+            req:  The request to add MCSP authentication information to. Must contain a key to a dictionary
+            called headers.
+        """
+        headers = req.get('headers')
+        bearer_token = self.token_manager.get_token()
+        headers['Authorization'] = 'Bearer {0}'.format(bearer_token)
+
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
+        """Set the flag that indicates whether verification of the server's SSL certificate should be
+        disabled or not. Defaults to False.
+
+        Args:
+            status: Set to true in order to disable SSL certificate verification. Defaults to False.
+
+        Raises:
+            TypeError: The `status` is not a bool.
+        """
+        self.token_manager.set_disable_ssl_verification(status)
+
+    def set_headers(self, headers: Dict[str, str]) -> None:
+        """Default headers to be sent with every MCSP token request.
+
+        Args:
+            headers: The headers to be sent with every MCSP token request.
+        """
+        self.token_manager.set_headers(headers)
+
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
+        """Sets the proxies the token manager will use to communicate with MCSP on behalf of the host.
+
+        Args:
+            proxies: Dictionary for mapping request protocol to proxy URL.
+            proxies.http (optional): The proxy endpoint to use for HTTP requests.
+            proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+        """
+        self.token_manager.set_proxies(proxies)

--- a/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
@@ -83,7 +83,7 @@ class VPCInstanceAuthenticator(Authenticator):
             Authorization: Bearer <bearer-token>
 
         Args:
-            req: The request to add IAM authentication information too. Must contain a key to a dictionary
+            req: The request to add IAM authentication information to. Must contain a key to a dictionary
             called headers.
         """
         headers = req.get('headers')

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -23,6 +23,7 @@ from .authenticators import (
     IAMAuthenticator,
     NoAuthAuthenticator,
     VPCInstanceAuthenticator,
+    MCSPAuthenticator,
 )
 from .utils import read_external_sources
 
@@ -101,6 +102,11 @@ def __construct_authenticator(config: dict) -> Authenticator:
         authenticator = VPCInstanceAuthenticator(
             iam_profile_crn=config.get('IAM_PROFILE_CRN'),
             iam_profile_id=config.get('IAM_PROFILE_ID'),
+            url=config.get('AUTH_URL'),
+        )
+    elif auth_type == Authenticator.AUTHTYPE_MCSP.lower():
+        authenticator = MCSPAuthenticator(
+            apikey=config.get('APIKEY'),
             url=config.get('AUTH_URL'),
         )
     elif auth_type == Authenticator.AUTHTYPE_NOAUTH.lower():

--- a/ibm_cloud_sdk_core/token_managers/mcsp_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/mcsp_token_manager.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+
+# Copyright 2023 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Dict, Optional
+
+from .jwt_token_manager import JWTTokenManager
+
+
+class MCSPTokenManager(JWTTokenManager):
+    """The MCSPTokenManager accepts a user-supplied apikey and performs the necessary interactions with
+    the Multi-Cloud Saas Platform (MCSP) token service to obtain an MCSP access token (a bearer token).
+    When the access token expires, a new access token is obtained from the token server.
+
+    Keyword Arguments:
+        apikey: The apikey for authentication [required].
+        url: The endpoint for JWT token requests [required].
+        disable_ssl_verification: Disable ssl verification. Defaults to False.
+        headers: Headers to be sent with every service token request. Defaults to None.
+        proxies: Proxies to use for making request. Defaults to None.
+        proxies.http (optional): The proxy endpoint to use for HTTP requests.
+        proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+    """
+
+    TOKEN_NAME = 'token'
+    OPERATION_PATH = '/siusermgr/api/1.0/apikeys/token'
+
+    def __init__(
+        self,
+        apikey: str,
+        url: str,
+        *,
+        disable_ssl_verification: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        proxies: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.apikey = apikey
+        self.headers = headers
+        if self.headers is None:
+            self.headers = {}
+        self.headers['Content-Type'] = 'application/json'
+        self.headers['Accept'] = 'application/json'
+        self.proxies = proxies
+        super().__init__(url, disable_ssl_verification=disable_ssl_verification, token_name=self.TOKEN_NAME)
+
+    def request_token(self) -> dict:
+        """Makes a request for a token."""
+        response = self._request(
+            method='POST',
+            headers=self.headers,
+            url=self.url + self.OPERATION_PATH,
+            data=json.dumps({"apikey": self.apikey}),
+            proxies=self.proxies,
+        )
+        return response
+
+    def set_headers(self, headers: Dict[str, str]) -> None:
+        """Headers to be sent with every MCSP token request.
+
+        Args:
+            headers: The headers to be sent with every MCSP token request.
+        """
+        if isinstance(headers, dict):
+            self.headers = headers
+        else:
+            raise TypeError('headers must be a dictionary')
+
+    def set_proxies(self, proxies: Dict[str, str]) -> None:
+        """Sets the proxies the token manager will use to communicate with MCSP on behalf of the host.
+
+        Args:
+            proxies: Proxies to use for making request. Defaults to None.
+            proxies.http (optional): The proxy endpoint to use for HTTP requests.
+            proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+        """
+        if isinstance(proxies, dict):
+            self.proxies = proxies
+        else:
+            raise TypeError('proxies must be a dictionary')

--- a/resources/ibm-credentials-mcsp.env
+++ b/resources/ibm-credentials-mcsp.env
@@ -1,0 +1,3 @@
+SERVICE1_AUTH_TYPE=mcsp
+SERVICE1_APIKEY=my-api-key
+SERVICE1_AUTH_URL=https://mcsp.ibm.com

--- a/test/test_mcsp_authenticator.py
+++ b/test/test_mcsp_authenticator.py
@@ -1,0 +1,176 @@
+# pylint: disable=missing-docstring
+import json
+import time
+import jwt
+import pytest
+import responses
+
+from ibm_cloud_sdk_core.authenticators import MCSPAuthenticator, Authenticator
+
+
+OPERATION_PATH = '/siusermgr/api/1.0/apikeys/token'
+MOCK_URL = 'https://mcsp.ibm.com'
+
+
+def test_mcsp_authenticator():
+    authenticator = MCSPAuthenticator('my-api-key', MOCK_URL)
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_MCSP
+    assert authenticator.token_manager.url == MOCK_URL
+    assert authenticator.token_manager.disable_ssl_verification is False
+    assert authenticator.token_manager.headers == {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+    }
+    assert authenticator.token_manager.proxies is None
+
+    authenticator.set_disable_ssl_verification(True)
+    assert authenticator.token_manager.disable_ssl_verification is True
+
+    with pytest.raises(TypeError) as err:
+        authenticator.set_headers('dummy')
+    assert str(err.value) == 'headers must be a dictionary'
+
+    authenticator.set_headers({'dummy': 'headers'})
+    assert authenticator.token_manager.headers == {'dummy': 'headers'}
+
+    with pytest.raises(TypeError) as err:
+        authenticator.set_proxies('dummy')
+    assert str(err.value) == 'proxies must be a dictionary'
+
+    authenticator.set_proxies({'dummy': 'proxies'})
+    assert authenticator.token_manager.proxies == {'dummy': 'proxies'}
+
+
+def test_disable_ssl_verification():
+    authenticator = MCSPAuthenticator('my-api-key', MOCK_URL, disable_ssl_verification=True)
+    assert authenticator.token_manager.disable_ssl_verification is True
+
+    authenticator.set_disable_ssl_verification(False)
+    assert authenticator.token_manager.disable_ssl_verification is False
+
+
+def test_invalid_disable_ssl_verification_type():
+    with pytest.raises(TypeError) as err:
+        authenticator = MCSPAuthenticator('my-api-key', MOCK_URL, disable_ssl_verification='True')
+    assert str(err.value) == 'disable_ssl_verification must be a bool'
+
+    authenticator = MCSPAuthenticator('my-api-key', MOCK_URL)
+    assert authenticator.token_manager.disable_ssl_verification is False
+
+    with pytest.raises(TypeError) as err:
+        authenticator.set_disable_ssl_verification('True')
+    assert str(err.value) == 'status must be a bool'
+
+
+def test_mcsp_authenticator_validate_failed():
+    with pytest.raises(ValueError) as err:
+        MCSPAuthenticator(apikey=None, url=MOCK_URL)
+    assert str(err.value) == 'The apikey shouldn\'t be None.'
+
+    with pytest.raises(ValueError) as err:
+        MCSPAuthenticator(apikey='my-api-key', url=None)
+    assert str(err.value) == 'The url shouldn\'t be None.'
+
+
+# utility function to construct a mock token server response containing an access token.
+def get_mock_token_response(issued_at, time_to_live) -> str:
+    access_token_layout = {
+        "username": "dummy",
+        "role": "Admin",
+        "permissions": ["administrator", "manage_catalog"],
+        "sub": "admin",
+        "iss": "sss",
+        "aud": "sss",
+        "uid": "sss",
+        "iat": issued_at,
+        "exp": issued_at + time_to_live,
+    }
+
+    access_token = jwt.encode(
+        access_token_layout, 'secret', algorithm='HS256', headers={'kid': '230498151c214b788dd97f22b85410a5'}
+    )
+
+    token_server_response = {"token": access_token, "token_type": "jwt", "expires_in": time_to_live}
+    # For convenience, return both the server response and the access_token.
+    return (json.dumps(token_server_response), access_token)
+
+
+@responses.activate
+def test_get_token():
+    (response, access_token) = get_mock_token_response(time.time(), 7200)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200)
+
+    auth_headers = {'Host': 'mcsp.cloud.ibm.com:443'}
+    authenticator = MCSPAuthenticator(apikey='my-api-key', url=MOCK_URL, headers=auth_headers)
+
+    # Authenticate the request and verify the Authorization header.
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] == 'Bearer ' + access_token
+
+    # Verify that the "get token" request contained the Host header.
+    assert responses.calls[0].request.headers.get('Host') == 'mcsp.cloud.ibm.com:443'
+
+
+@responses.activate
+def test_get_token_cached():
+    (response, access_token) = get_mock_token_response(time.time(), 7200)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200)
+
+    authenticator = MCSPAuthenticator(apikey='my-api-key', url=MOCK_URL)
+
+    # Authenticate the request and verify the Authorization header.
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] == 'Bearer ' + access_token
+
+    # Authenticate a second request and verify that we used the same access token.
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] == 'Bearer ' + access_token
+
+
+@responses.activate
+def test_get_token_background_refresh():
+    t1 = time.time()
+    t2 = t1 + 7200
+
+    # Setup the first token response.
+    (response1, access_token1) = get_mock_token_response(t1, 7200)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response1, status=200)
+
+    # Setup the second token response.
+    (response2, access_token2) = get_mock_token_response(t2, 7200)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response2, status=200)
+
+    authenticator = MCSPAuthenticator(apikey="my-api-key", url=MOCK_URL)
+
+    # Authenticate the request and verify that the first access_token is used.
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] == 'Bearer ' + access_token1
+
+    # Now put the token manager in the refresh window to trigger a background refresh scenario.
+    authenticator.token_manager.refresh_time = t1 - 1
+
+    # Authenticate a second request and verify that the correct access token is used.
+    # Note: Ideally, the token manager would trigger the refresh in a separate thread
+    # and it "should" return the first access token for this second authentication request
+    # while the token manager is obtaining a new access token.
+    # Unfortunately, the TokenManager class  method does the refresh request synchronously,
+    # so we get back the second access token here instead.
+    # If we "fix" the TokenManager class to refresh asynchronously, we'll need to
+    # change this test case to expect the first access token here.
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] == 'Bearer ' + access_token2
+
+    # Wait for the background refresh to finish.
+    # No need to wait due to the synchronous logic in the TokenManager class mentioned above.
+    # time.sleep(2)
+
+    # Authenticate another request and verify that the second access token is used again.
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] == 'Bearer ' + access_token2

--- a/test/test_mcsp_token_manager.py
+++ b/test/test_mcsp_token_manager.py
@@ -1,0 +1,66 @@
+# pylint: disable=missing-docstring
+import json
+import time
+
+import jwt
+import pytest
+import responses
+
+from ibm_cloud_sdk_core import MCSPTokenManager, ApiException
+
+OPERATION_PATH = '/siusermgr/api/1.0/apikeys/token'
+MOCK_URL = 'https://mcsp.ibm.com'
+
+
+# utility function to construct a mock token server response containing an access token.
+def get_mock_token_response(issued_at, time_to_live) -> str:
+    access_token_layout = {
+        "username": "dummy",
+        "role": "Admin",
+        "permissions": ["administrator", "manage_catalog"],
+        "sub": "admin",
+        "iss": "sss",
+        "aud": "sss",
+        "uid": "sss",
+        "iat": issued_at,
+        "exp": issued_at + time_to_live,
+    }
+
+    access_token = jwt.encode(
+        access_token_layout, 'secret', algorithm='HS256', headers={'kid': '230498151c214b788dd97f22b85410a5'}
+    )
+
+    token_server_response = {"token": access_token, "token_type": "jwt", "expires_in": time_to_live}
+    # For convenience, return both the server response and the access_token.
+    return (json.dumps(token_server_response), access_token)
+
+
+@responses.activate
+def test_request_token():
+    (response, access_token) = get_mock_token_response(time.time(), 30)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200)
+
+    token_manager = MCSPTokenManager(apikey="my-api-key", url=MOCK_URL, disable_ssl_verification=True)
+    token = token_manager.get_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == MOCK_URL + OPERATION_PATH
+    assert token == access_token
+
+
+@responses.activate
+def test_request_token_unsuccessful():
+    response = """{
+        "errorCode": "BXNIM0415E",
+        "errorMessage": "Provided API key could not be found"
+    }
+    """
+    responses.add(responses.POST, url=MOCK_URL + OPERATION_PATH, body=response, status=400)
+
+    token_manager = MCSPTokenManager(apikey="bad-api-key", url=MOCK_URL)
+    with pytest.raises(ApiException):
+        token_manager.request_token()
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == MOCK_URL + OPERATION_PATH
+    assert responses.calls[0].response.text == response

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -364,6 +364,7 @@ def test_get_authenticator_from_credential_file():
     assert authenticator.token_manager.iam_profile_crn is None
     assert authenticator.token_manager.iam_profile_id is None
     assert authenticator.token_manager.url == 'http://169.254.169.254'
+    del os.environ['IBM_CREDENTIALS_FILE']
 
     file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-vpc.env')
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
@@ -373,6 +374,7 @@ def test_get_authenticator_from_credential_file():
     assert authenticator.token_manager.iam_profile_crn == 'crn:iam-profile1'
     assert authenticator.token_manager.iam_profile_id is None
     assert authenticator.token_manager.url == 'http://vpc.imds.com/api'
+    del os.environ['IBM_CREDENTIALS_FILE']
 
     file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-vpc.env')
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
@@ -382,6 +384,16 @@ def test_get_authenticator_from_credential_file():
     assert authenticator.token_manager.iam_profile_crn is None
     assert authenticator.token_manager.iam_profile_id == 'iam-profile1-id'
     assert authenticator.token_manager.url == 'http://169.254.169.254'
+    del os.environ['IBM_CREDENTIALS_FILE']
+
+    file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-mcsp.env')
+    os.environ['IBM_CREDENTIALS_FILE'] = file_path
+    authenticator = get_authenticator_from_environment('service1')
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_MCSP
+    assert authenticator.token_manager.url == 'https://mcsp.ibm.com'
+    assert authenticator.token_manager.apikey == 'my-api-key'
+    del os.environ['IBM_CREDENTIALS_FILE']
 
 
 def test_get_authenticator_from_credential_file_scope():
@@ -428,6 +440,18 @@ def test_get_authenticator_from_env_variables():
     assert authenticator.token_manager.scope == 'A B C D'
     del os.environ['SERVICE_2_APIKEY']
     del os.environ['SERVICE_2_SCOPE']
+
+    os.environ['SERVICE3_AUTH_TYPE'] = 'mCsP'
+    os.environ['SERVICE3_AUTH_URL'] = 'https://mcsp.ibm.com'
+    os.environ['SERVICE3_APIKEY'] = 'my-api-key'
+    authenticator = get_authenticator_from_environment('service3')
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_MCSP
+    assert authenticator.token_manager.apikey == 'my-api-key'
+    assert authenticator.token_manager.url == 'https://mcsp.ibm.com'
+    del os.environ['SERVICE3_APIKEY']
+    del os.environ['SERVICE3_AUTH_TYPE']
+    del os.environ['SERVICE3_AUTH_URL']
 
 
 def test_vcap_credentials():

--- a/test_integration/test_mcsp_authenticator_integration.py
+++ b/test_integration/test_mcsp_authenticator_integration.py
@@ -1,0 +1,28 @@
+# pylint: disable=missing-docstring
+import os
+
+from ibm_cloud_sdk_core import get_authenticator_from_environment
+
+# Note: Only the unit tests are run by default.
+#
+# In order to test with a live MCSP token server, create file "mcsptest.env" in the project root.
+# It should look like this:
+#
+# 	MCSPTEST_AUTH_URL=<url>   e.g. https://iam.cloud.ibm.com
+# 	MCSPTEST_AUTH_TYPE=mcsp
+# 	MCSPTEST_APIKEY=<apikey>
+#
+# Then run this command:
+# pytest test_integration/test_mcsp_authenticator_integration.py
+
+
+def test_mcsp_authenticator():
+    os.environ['IBM_CREDENTIALS_FILE'] = 'mcsptest.env'
+
+    authenticator = get_authenticator_from_environment('mcsptest1')
+    assert authenticator is not None
+
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] is not None
+    assert 'Bearer' in request['headers']['Authorization']


### PR DESCRIPTION
This commit introduces the new MCSPAuthenticator that can be used to exchange an apikey for an MCSP access token using the Multi-Cloud Saas Platform authentication token server's 'POST /siusermgr/api/1.0/apikeys/token' operation.