### PR TITLE
fix: more consistent naming of HTTP status code related attributes

### DIFF
--- a/ibm_cloud_sdk_core/api_exception.py
+++ b/ibm_cloud_sdk_core/api_exception.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
 from http import HTTPStatus
 from typing import Optional
 
@@ -39,15 +40,28 @@ class ApiException(Exception):
         # Call the base class constructor with the parameters it needs
         super().__init__(message)
         self.message = message
-        self.code = code
+        self.status_code = code
         self.http_response = http_response
         self.global_transaction_id = None
         if http_response is not None:
             self.global_transaction_id = http_response.headers.get('X-Global-Transaction-ID')
             self.message = self.message if self.message else self._get_error_message(http_response)
 
+    # pylint: disable=fixme
+    # TODO: delete this by the end of 2024.
+    @property
+    def code(self):
+        """The old `code` property with a deprecation warning."""
+
+        warnings.warn(
+            'Using the `code` attribute on the `ApiException` is deprecated and'
+            'will be removed in the future. Use `status_code` instead.',
+            DeprecationWarning,
+        )
+        return self.status_code
+
     def __str__(self) -> str:
-        msg = 'Error: ' + str(self.message) + ', Code: ' + str(self.code)
+        msg = 'Error: ' + str(self.message) + ', Status code: ' + str(self.status_code)
         if self.global_transaction_id is not None:
             msg += ' , X-global-transaction-id: ' + str(self.global_transaction_id)
         return msg

--- a/ibm_cloud_sdk_core/detailed_response.py
+++ b/ibm_cloud_sdk_core/detailed_response.py
@@ -65,7 +65,7 @@ class DetailedResponse:
         """
         return self.headers
 
-    def get_status_code(self) -> int:
+    def get_status_code(self) -> Union[int, None]:
         """The HTTP status code of the service request.
 
         Returns:

--- a/test/test_api_exception.py
+++ b/test/test_api_exception.py
@@ -85,4 +85,4 @@ def test_api_exception():
     mock_response = requests.get('https://test-for-text.com', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'plain text error'
-    assert str(exception) == 'Error: plain text error, Code: 500 , X-global-transaction-id: xx'
+    assert str(exception) == 'Error: plain text error, Status code: 500 , X-global-transaction-id: xx'

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -356,7 +356,7 @@ def test_request_server_error():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
-    assert err.value.code == 500
+    assert err.value.status_code == 500
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == 'internal server error'
 
@@ -398,7 +398,7 @@ def test_request_success_invalid_json():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
-    assert err.value.code == 200
+    assert err.value.status_code == 200
     assert err.value.http_response.headers['Content-Type'] == 'application/json; charset=utf8'
     assert isinstance(err.value.__cause__, requests.exceptions.JSONDecodeError)
     assert "Expecting ':' delimiter: line 1" in str(err.value.__cause__)
@@ -452,7 +452,7 @@ def test_request_fail_401_nonerror_json():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
-    assert err.value.code == 401
+    assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == error_msg
 
@@ -472,7 +472,7 @@ def test_request_fail_401_error_json():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
-    assert err.value.code == 401
+    assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == error_msg
 
@@ -491,7 +491,7 @@ def test_request_fail_401_nonjson():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
-    assert err.value.code == 401
+    assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'text/plain'
     assert err.value.message == response_body
 
@@ -513,7 +513,7 @@ def test_request_fail_401_badjson():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
-    assert err.value.code == 401
+    assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == response_body
 

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# pylint: disable=missing-docstring,protected-access,too-few-public-methods
+# pylint: disable=missing-docstring,protected-access,too-few-public-methods,too-many-lines
 import gzip
 import json
 import os
@@ -356,6 +356,7 @@ def test_request_server_error():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
+    assert err.value.code == 500
     assert err.value.status_code == 500
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == 'internal server error'
@@ -398,6 +399,7 @@ def test_request_success_invalid_json():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
+    assert err.value.code == 200
     assert err.value.status_code == 200
     assert err.value.http_response.headers['Content-Type'] == 'application/json; charset=utf8'
     assert isinstance(err.value.__cause__, requests.exceptions.JSONDecodeError)
@@ -452,6 +454,7 @@ def test_request_fail_401_nonerror_json():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
+    assert err.value.code == 401
     assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == error_msg
@@ -472,6 +475,7 @@ def test_request_fail_401_error_json():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
+    assert err.value.code == 401
     assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == error_msg
@@ -491,6 +495,7 @@ def test_request_fail_401_nonjson():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
+    assert err.value.code == 401
     assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'text/plain'
     assert err.value.message == response_body
@@ -513,6 +518,7 @@ def test_request_fail_401_badjson():
         service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
         prepped = service.prepare_request('GET', url='')
         service.send(prepped)
+    assert err.value.code == 401
     assert err.value.status_code == 401
     assert err.value.http_response.headers['Content-Type'] == 'application/json'
     assert err.value.message == response_body

--- a/test/test_container_token_manager.py
+++ b/test/test_container_token_manager.py
@@ -251,7 +251,7 @@ def test_authenticate_fail_iam():
     with pytest.raises(ApiException) as err:
         authenticator.authenticate(request)
 
-    assert str(err.value) == 'Error: Bad Request, Code: 400'
+    assert str(err.value) == 'Error: Bad Request, Status code: 400'
 
 
 @mock_iam_response


### PR DESCRIPTION
This commit fixes a small inconsistency in the naming
of the HTTP status code attributes between the successful
and the error responses.