### PR TITLE
fix: adjust IAM token expiration time

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-01-24T12:09:17Z",
+  "generated_at": "2024-02-26T20:31:05Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -242,7 +242,7 @@
         "hashed_secret": "c8f0df25bade89c1873f5f01b85bcfb921443ac6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 30,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -250,7 +250,7 @@
         "hashed_secret": "f06e1073ca9afdd800a2cf27f944d06530b5b755",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 31,
         "type": "JSON Web Token",
         "verified_result": null
       },
@@ -258,7 +258,7 @@
         "hashed_secret": "360c23c1ac7d9d6dad1d0710606b0df9de6e1a18",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 35,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -266,7 +266,7 @@
         "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 139,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -327,10 +327,26 @@
     ],
     "test/test_iam_token_manager.py": [
       {
+        "hashed_secret": "c8f0df25bade89c1873f5f01b85bcfb921443ac6",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 28,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f06e1073ca9afdd800a2cf27f944d06530b5b755",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 29,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
         "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 52,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -338,7 +354,7 @@
         "hashed_secret": "b3f00e146afe19aab0069029b7fb3926ad756d26",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 103,
+        "line_number": 129,
         "type": "Hex High Entropy String",
         "verified_result": null
       },
@@ -346,7 +362,7 @@
         "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 165,
+        "line_number": 191,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -444,13 +460,21 @@
         "hashed_secret": "c8f0df25bade89c1873f5f01b85bcfb921443ac6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 29,
+        "type": "JSON Web Token",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "f06e1073ca9afdd800a2cf27f944d06530b5b755",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 30,
         "type": "JSON Web Token",
         "verified_result": null
       }
     ]
   },
-  "version": "0.13.1+ibm.61.dss",
+  "version": "0.13.1+ibm.62.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/test/test_vpc_instance_token_manager.py
+++ b/test/test_vpc_instance_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2021 IBM All Rights Reserved.
+# Copyright 2021, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 # pylint: disable=missing-docstring
 import json
 import logging
+import time
 
 import pytest
 import responses
@@ -25,11 +26,17 @@ from ibm_cloud_sdk_core import ApiException, VPCInstanceTokenManager
 
 
 # pylint: disable=line-too-long
-TEST_ACCESS_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI'
+TEST_ACCESS_TOKEN_1 = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImhlbGxvIiwicm9sZSI6InVzZXIiLCJwZXJtaXNzaW9ucyI6WyJhZG1pbmlzdHJhdG9yIiwiZGVwbG95bWVudF9hZG1pbiJdLCJzdWIiOiJoZWxsbyIsImlzcyI6IkpvaG4iLCJhdWQiOiJEU1giLCJ1aWQiOiI5OTkiLCJpYXQiOjE1NjAyNzcwNTEsImV4cCI6MTU2MDI4MTgxOSwianRpIjoiMDRkMjBiMjUtZWUyZC00MDBmLTg2MjMtOGNkODA3MGI1NDY4In0.cIodB4I6CCcX8vfIImz7Cytux3GpWyObt9Gkur5g1QI'
+TEST_ACCESS_TOKEN_2 = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6IjIzMDQ5ODE1MWMyMTRiNzg4ZGQ5N2YyMmI4NTQxMGE1In0.eyJ1c2VybmFtZSI6ImR1bW15Iiwicm9sZSI6IkFkbWluIiwicGVybWlzc2lvbnMiOlsiYWRtaW5pc3RyYXRvciIsIm1hbmFnZV9jYXRhbG9nIl0sInN1YiI6ImFkbWluIiwiaXNzIjoic3NzIiwiYXVkIjoic3NzIiwidWlkIjoic3NzIiwiaWF0IjozNjAwLCJleHAiOjE2MjgwMDcwODF9.zvUDpgqWIWs7S1CuKv40ERw1IZ5FqSFqQXsrwZJyfRM'
 TEST_TOKEN = 'abc123'
 TEST_IAM_TOKEN = 'iam-abc123'
 TEST_IAM_PROFILE_CRN = 'crn:iam-profile:123'
 TEST_IAM_PROFILE_ID = 'iam-id-123'
+EXPIRATION_WINDOW = 10
+
+
+def _get_current_time() -> int:
+    return int(time.time())
 
 
 def test_constructor():
@@ -272,7 +279,7 @@ def test_access_token():
         'access_token': TEST_TOKEN,
     }
     response_iam = {
-        'access_token': TEST_ACCESS_TOKEN,
+        'access_token': TEST_ACCESS_TOKEN_1,
     }
 
     responses.add(
@@ -290,6 +297,54 @@ def test_access_token():
     assert token_manager.refresh_time == 0
 
     token_manager.get_token()
-    assert token_manager.access_token == TEST_ACCESS_TOKEN
+    assert token_manager.access_token == TEST_ACCESS_TOKEN_1
     assert token_manager.expire_time > 0
     assert token_manager.refresh_time > 0
+
+
+@responses.activate
+def test_get_token_success():
+    token_manager = VPCInstanceTokenManager()
+
+    # Mock the retrieve instance identity token method.
+    def mock_retrieve_instance_identity_token():
+        return TEST_TOKEN
+
+    token_manager.retrieve_instance_identity_token = mock_retrieve_instance_identity_token
+
+    response1 = {
+        'access_token': TEST_ACCESS_TOKEN_1,
+    }
+    response2 = {
+        'access_token': TEST_ACCESS_TOKEN_2,
+    }
+
+    responses.add(
+        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response1), status=200
+    )
+
+    access_token = token_manager.get_token()
+    assert access_token == TEST_ACCESS_TOKEN_1
+    assert token_manager.access_token == TEST_ACCESS_TOKEN_1
+
+    # Verify that the token manager returns the cached value.
+    # Before we call `get_token` again, set the expiration and refresh time
+    # so that we do not fetch a new access token.
+    # This is necessary because we are using a fixed JWT response.
+    token_manager.expire_time = _get_current_time() + 1000
+    token_manager.refresh_time = _get_current_time() + 1000
+    access_token = token_manager.get_token()
+    assert access_token == TEST_ACCESS_TOKEN_1
+    assert token_manager.access_token == TEST_ACCESS_TOKEN_1
+
+    # Force expiration to get the second token.
+    # We'll set the expiration time to be current-time + EXPIRATION_WINDOW (10 secs)
+    # because we want the access token to be considered as "expired"
+    # when we reach the IAM-server reported expiration time minus 10 secs.
+    responses.add(
+        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response2), status=200
+    )
+    token_manager.expire_time = _get_current_time() + EXPIRATION_WINDOW
+    access_token = token_manager.get_token()
+    assert access_token == TEST_ACCESS_TOKEN_2
+    assert token_manager.access_token == TEST_ACCESS_TOKEN_2


### PR DESCRIPTION
This commit changes the IAM, Container and VPC Instance authenticators slightly so that an IAM access token will be viewed as "expired" when the current time is within 10 seconds of the official expiration time. IOW, we'll expire the access token 10 secs earlier than the IAM server-computed expiration time.
We're doing this to avoid a scenario where
an IBM Cloud service receives a request along
with an "almost expired" access token and then uses that token to perform downstream requests in a
somewhat longer-running transaction and then the
access token expires while that transaction is
still active.