### PR TITLE
refactor(BaseService): improve prepare_request() docstring

### DIFF
--- a/ibm_cloud_sdk_core/api_exception.py
+++ b/ibm_cloud_sdk_core/api_exception.py
@@ -54,7 +54,7 @@ class ApiException(Exception):
         """The old `code` property with a deprecation warning."""
 
         warnings.warn(
-            'Using the `code` attribute on the `ApiException` is deprecated and'
+            'Using the `code` attribute on the `ApiException` is deprecated and '
             'will be removed in the future. Use `status_code` instead.',
             DeprecationWarning,
         )

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -376,8 +376,10 @@ class BaseService:
             url: The origin + pathname according to WHATWG spec.
 
         Keyword Arguments:
-            headers: Headers of the request.
-            params: Querystring data to be appended to the url.
+            headers: A dictionary containing the headers to be included in the request.
+                    Entries with a value of None will be ignored (excluded).
+            params: A dictionary containing the query parameters to be included in the request.
+                    Entries with a value of None will be ignored (excluded).
             data: The request body. Converted to json if a dict.
             files: 'files' can be a dictionary (i.e { '<part-name>': (<tuple>)}),
                 or a list of tuples [ (<part-name>, (<tuple>))... ]

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2019 IBM All Rights Reserved.
+# Copyright 2019, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ import gzip
 import io
 import json as json_import
 import logging
-import platform
 from http.cookiejar import CookieJar
 from os.path import basename
 from typing import Dict, List, Optional, Tuple, Union
@@ -42,7 +41,7 @@ from .utils import (
     SSLHTTPAdapter,
     GzipStream,
 )
-from .version import __version__
+from .private_helpers import _build_user_agent
 
 # Uncomment this to enable http debugging
 # import http.client as http_client
@@ -82,7 +81,6 @@ class BaseService:
         ValueError: If Authenticator is not provided or invalid type.
     """
 
-    SDK_NAME = 'ibm-python-sdk-core'
     ERROR_MSG_DISABLE_SSL = (
         'The connection failed because the SSL certificate is not valid. To use a self-signed '
         'certificate, disable verification of the server\'s SSL certificate by invoking the '
@@ -106,7 +104,7 @@ class BaseService:
         self.disable_ssl_verification = disable_ssl_verification
         self.default_headers = None
         self.enable_gzip_compression = enable_gzip_compression
-        self._set_user_agent_header(self._build_user_agent())
+        self._set_user_agent_header(_build_user_agent())
         self.retry_config = None
         self.http_adapter = SSLHTTPAdapter(_disable_ssl_verification=self.disable_ssl_verification)
         if not self.authenticator:
@@ -150,15 +148,6 @@ class BaseService:
         self.http_adapter = SSLHTTPAdapter(_disable_ssl_verification=self.disable_ssl_verification)
         self.http_client.mount('http://', self.http_adapter)
         self.http_client.mount('https://', self.http_adapter)
-
-    @staticmethod
-    def _get_system_info() -> str:
-        return '{0} {1} {2}'.format(
-            platform.system(), platform.release(), platform.python_version()  # OS  # OS version  # Python version
-        )
-
-    def _build_user_agent(self) -> str:
-        return '{0}-{1} {2}'.format(self.SDK_NAME, __version__, self._get_system_info())
 
     def configure_service(self, service_name: str) -> None:
         """Look for external configuration of a service. Set service properties.

--- a/ibm_cloud_sdk_core/private_helpers.py
+++ b/ibm_cloud_sdk_core/private_helpers.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+
+# Copyright 2021 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# from ibm_cloud_sdk_core.authenticators import Authenticator
+
+import platform
+from .version import __version__
+
+SDK_NAME = 'ibm-python-sdk-core'
+
+
+def _get_system_info() -> str:
+    return 'os.name={0} os.version={1} python.version={2}'.format(
+        platform.system(), platform.release(), platform.python_version()
+    )
+
+
+def _build_user_agent(component: str = None) -> str:
+    sub_component = ""
+    if component is not None:
+        sub_component = '/{0}'.format(component)
+    return '{0}{1}-{2} {3}'.format(SDK_NAME, sub_component, __version__, _get_system_info())

--- a/ibm_cloud_sdk_core/token_managers/container_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/container_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2021 IBM All Rights Reserved.
+# Copyright 2021, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import logging
 from typing import Dict, Optional
 
 from .iam_request_based_token_manager import IAMRequestBasedTokenManager
+from ..private_helpers import _build_user_agent
 
 
 logger = logging.getLogger(__name__)
@@ -111,6 +112,7 @@ class ContainerTokenManager(IAMRequestBasedTokenManager):
         self.iam_profile_id = iam_profile_id
 
         self.request_payload['grant_type'] = 'urn:ibm:params:oauth:grant-type:cr-token'
+        self._set_user_agent(_build_user_agent('container-authenticator'))
 
     def retrieve_cr_token(self) -> str:
         """Retrieves the CR token for the current compute resource by reading it from the local file system.

--- a/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/cp4d_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2019 IBM All Rights Reserved.
+# Copyright 2019, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 import json
 from typing import Dict, Optional
 
+from ..private_helpers import _build_user_agent
 from .jwt_token_manager import JWTTokenManager
 
 
@@ -76,12 +77,21 @@ class CP4DTokenManager(JWTTokenManager):
         self.headers['Content-Type'] = 'application/json'
         self.proxies = proxies
         super().__init__(url, disable_ssl_verification=disable_ssl_verification, token_name=self.TOKEN_NAME)
+        self._set_user_agent(_build_user_agent('cp4d-authenticator'))
 
     def request_token(self) -> dict:
         """Makes a request for a token."""
+        required_headers = {
+            'User-Agent': self.user_agent,
+        }
+        request_headers = {}
+        if self.headers is not None and isinstance(self.headers, dict):
+            request_headers.update(self.headers)
+        request_headers.update(required_headers)
+
         response = self._request(
             method='POST',
-            headers=self.headers,
+            headers=request_headers,
             url=self.url,
             data=json.dumps({"username": self.username, "password": self.password, "api_key": self.apikey}),
             proxies=self.proxies,

--- a/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
@@ -98,9 +98,15 @@ class IAMRequestBasedTokenManager(JWTTokenManager):
         Returns:
              A dictionary containing the bearer token to be subsequently used service requests.
         """
-        headers = {'Content-type': 'application/x-www-form-urlencoded', 'Accept': 'application/json'}
+        required_headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/json',
+            'User-Agent': self._get_user_agent(),
+        }
+        request_headers = {}
         if self.headers is not None and isinstance(self.headers, dict):
-            headers.update(self.headers)
+            request_headers.update(self.headers)
+        request_headers.update(required_headers)
 
         data = dict(self.request_payload)
 
@@ -115,7 +121,7 @@ class IAMRequestBasedTokenManager(JWTTokenManager):
         response = self._request(
             method='POST',
             url=(self.url + self.OPERATION_PATH) if self.url else self.url,
-            headers=headers,
+            headers=request_headers,
             data=data,
             auth_tuple=auth_tuple,
             proxies=self.proxies,

--- a/ibm_cloud_sdk_core/token_managers/iam_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2019 IBM All Rights Reserved.
+# Copyright 2019, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 from typing import Dict, Optional
 
 from .iam_request_based_token_manager import IAMRequestBasedTokenManager
+from ..private_helpers import _build_user_agent
 
 
 class IAMTokenManager(IAMRequestBasedTokenManager):
@@ -88,3 +89,5 @@ class IAMTokenManager(IAMRequestBasedTokenManager):
         self.request_payload['grant_type'] = 'urn:ibm:params:oauth:grant-type:apikey'
         self.request_payload['apikey'] = self.apikey
         self.request_payload['response_type'] = 'cloud_iam'
+
+        self._set_user_agent(_build_user_agent('iam-authenticator'))

--- a/ibm_cloud_sdk_core/token_managers/mcsp_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/mcsp_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2023 IBM All Rights Reserved.
+# Copyright 2023, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 import json
 from typing import Dict, Optional
 
+from ..private_helpers import _build_user_agent
 from .jwt_token_manager import JWTTokenManager
 
 
@@ -55,12 +56,21 @@ class MCSPTokenManager(JWTTokenManager):
         self.headers['Accept'] = 'application/json'
         self.proxies = proxies
         super().__init__(url, disable_ssl_verification=disable_ssl_verification, token_name=self.TOKEN_NAME)
+        self._set_user_agent(_build_user_agent('mcsp-authenticator'))
 
     def request_token(self) -> dict:
         """Makes a request for a token."""
+        required_headers = {
+            'User-Agent': self.user_agent,
+        }
+        request_headers = {}
+        if self.headers is not None and isinstance(self.headers, dict):
+            request_headers.update(self.headers)
+        request_headers.update(required_headers)
+
         response = self._request(
             method='POST',
-            headers=self.headers,
+            headers=request_headers,
             url=self.url + self.OPERATION_PATH,
             data=json.dumps({"apikey": self.apikey}),
             proxies=self.proxies,

--- a/ibm_cloud_sdk_core/token_managers/token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2020 IBM All Rights Reserved.
+# Copyright 2020, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ class TokenManager(ABC):
         lock (Lock): Lock variable to serialize access to refresh/request times
         http_config (dict): A dictionary containing values that control the timeout, proxies, and etc of HTTP requests.
         access_token (str): The latest stored access token
+        user_agent (str): The User-Agent header value to be included in each outbound token request
     """
 
     def __init__(self, url: str, *, disable_ssl_verification: bool = False):
@@ -60,6 +61,7 @@ class TokenManager(ABC):
         self.lock = Lock()
         self.http_config = {}
         self.access_token = None
+        self.user_agent = None
 
     def get_token(self) -> str:
         """Get a token to be used for authentication.
@@ -94,6 +96,12 @@ class TokenManager(ABC):
             self.disable_ssl_verification = status
         else:
             raise TypeError('status must be a bool')
+
+    def _set_user_agent(self, user_agent: str = None) -> None:
+        self.user_agent = user_agent
+
+    def _get_user_agent(self) -> str:
+        return self.user_agent
 
     def paced_request_token(self) -> None:
         """

--- a/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
@@ -18,6 +18,7 @@ import json
 import logging
 from typing import Optional
 
+from ..private_helpers import _build_user_agent
 from .jwt_token_manager import JWTTokenManager
 
 
@@ -64,6 +65,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             url = self.DEFAULT_IMS_ENDPOINT
 
         super().__init__(url, token_name=self.TOKEN_NAME)
+        self._set_user_agent(_build_user_agent('vpc-instance-authenticator'))
 
         self.iam_profile_crn = iam_profile_crn
         self.iam_profile_id = iam_profile_id
@@ -92,6 +94,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             'Content-Type': 'application/json',
             'Accept': 'application/json',
             'Authorization': 'Bearer ' + instance_identity_token,
+            'User-Agent': self._get_user_agent(),
         }
 
         logger.debug('Invoking VPC \'create_iam_token\' operation: %s', url)
@@ -138,6 +141,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             'Content-type': 'application/json',
             'Accept': 'application/json',
             'Metadata-Flavor': 'ibm',
+            'User-Agent': self._get_user_agent(),
         }
 
         request_body = {'expires_in': 300}

--- a/test/test_base_service.py
+++ b/test/test_base_service.py
@@ -1,5 +1,21 @@
-# coding=utf-8
+# coding: utf-8
+
+# Copyright 2019, 2024 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # pylint: disable=missing-docstring,protected-access,too-few-public-methods,too-many-lines
+
 import gzip
 import json
 import os
@@ -802,7 +818,7 @@ def test_user_agent_header():
     service = AnyServiceV1('2018-11-20', authenticator=NoAuthAuthenticator())
     user_agent_header = service.user_agent_header
     assert user_agent_header is not None
-    assert user_agent_header['User-Agent'] is not None
+    assert user_agent_header['User-Agent'].startswith('ibm-python-sdk-core-')
 
     responses.add(responses.GET, 'https://gateway.watsonplatform.net/test/api', status=200, body='some text')
     prepped = service.prepare_request('GET', url='', headers={'user-agent': 'my_user_agent'})

--- a/test/test_container_token_manager.py
+++ b/test/test_container_token_manager.py
@@ -111,6 +111,9 @@ def test_request_token_auth_default():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == iam_url
     assert responses.calls[0].request.headers.get('Authorization') is None
+    assert (
+        responses.calls[0].request.headers.get('User-Agent').startswith('ibm-python-sdk-core/container-authenticator')
+    )
     assert json.loads(responses.calls[0].response.text)['access_token'] == TEST_ACCESS_TOKEN_1
 
 

--- a/test/test_cp4d_token_manager.py
+++ b/test/test_cp4d_token_manager.py
@@ -1,3 +1,19 @@
+# coding: utf-8
+
+# Copyright 2019, 2024 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # pylint: disable=missing-docstring
 import json
 import time
@@ -38,6 +54,7 @@ def test_request_token():
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == url + '/v1/authorize'
+    assert responses.calls[0].request.headers.get('User-Agent').startswith('ibm-python-sdk-core/cp4d-authenticator')
     assert token == access_token
 
     token_manager = CP4DTokenManager("username", "password", url + '/v1/authorize')

--- a/test/test_iam_token_manager.py
+++ b/test/test_iam_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2021, 2024 IBM All Rights Reserved.
+# Copyright 2019, 2024 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,6 +72,7 @@ def test_request_token_auth_default():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == iam_url
     assert responses.calls[0].request.headers.get('Authorization') is None
+    assert responses.calls[0].request.headers.get('User-Agent').startswith('ibm-python-sdk-core/iam-authenticator')
     assert responses.calls[0].response.text == response
 
 

--- a/test/test_mcsp_token_manager.py
+++ b/test/test_mcsp_token_manager.py
@@ -1,3 +1,19 @@
+# coding: utf-8
+
+# Copyright 2023, 2024 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # pylint: disable=missing-docstring
 import json
 import time
@@ -45,6 +61,7 @@ def test_request_token():
 
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == MOCK_URL + OPERATION_PATH
+    assert responses.calls[0].request.headers.get('User-Agent').startswith('ibm-python-sdk-core/mcsp-authenticator')
     assert token == access_token
 
 

--- a/test/test_vpc_instance_token_manager.py
+++ b/test/test_vpc_instance_token_manager.py
@@ -85,6 +85,7 @@ def test_retrieve_instance_identity_token(caplog):
     assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
     assert responses.calls[0].request.headers['Accept'] == 'application/json'
     assert responses.calls[0].request.headers['Metadata-Flavor'] == 'ibm'
+    assert responses.calls[0].request.headers['User-Agent'].startswith('ibm-python-sdk-core/vpc-instance-authenticator')
     assert responses.calls[0].request.params['version'] == '2022-03-01'
     assert responses.calls[0].request.body == '{"expires_in": 300}'
     assert ii_token == TEST_TOKEN
@@ -151,6 +152,7 @@ def test_request_token_with_crn(caplog):
     assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
     assert responses.calls[0].request.headers['Accept'] == 'application/json'
     assert responses.calls[0].request.headers['Authorization'] == 'Bearer ' + TEST_TOKEN
+    assert responses.calls[0].request.headers['User-Agent'].startswith('ibm-python-sdk-core/vpc-instance-authenticator')
     assert responses.calls[0].request.body == '{"trusted_profile": {"crn": "crn:iam-profile:123"}}'
     assert responses.calls[0].request.params['version'] == '2022-03-01'
     # Check the logs.


### PR DESCRIPTION
This commit simply modifies the docstring comments related to the
`headers` and `params` arguments to the `BaseService.prepare_request()`
function in order to clarify that any entries in either of the two dictionary
arguments will simply be ignored if they have a value of None.