### PR TITLE
fix: specify the maximum version of `requests` to avoid regression

### DIFF
--- a/ibm_cloud_sdk_core/utils.py
+++ b/ibm_cloud_sdk_core/utils.py
@@ -31,6 +31,8 @@ from urllib3.util.ssl_ import create_urllib3_context
 import dateutil.parser as date_parser
 
 
+# pylint: disable=fixme
+# TODO: revert the change in the `requirement.txt` once this class become deprecated!
 class SSLHTTPAdapter(HTTPAdapter):
     """Wraps the original HTTP adapter and adds additional SSL context."""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.31.0,<3.0.0
+requests>=2.31.0,<2.32.3
 urllib3>=2.1.0,<3.0.0
 python_dateutil>=2.8.2,<3.0.0
 PyJWT>=2.8.0,<3.0.0


### PR DESCRIPTION
Version `2.23.3` of the `requests` package broke our custom `SSLHTTPAdapter`. This commit defines the maximum version of that package, to make sure it will continue working without an issue. Note that, this is a short term solution only. For more details see this issue: https://github.com/psf/requests/issues/6730