### PR TITLE
test: minor updates to a few testcases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: jammy
 matrix:
   include:
     - python: 3.8
-    - python: 3.9
     - python: 3.10
     - python: 3.11
+    - python: 3.12
 
 cache: pip3
 

--- a/test/test_api_exception.py
+++ b/test/test_api_exception.py
@@ -74,6 +74,9 @@ def test_api_exception():
     mock_response = requests.get('https://test-errormessage.com', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'IAM error message'
+    assert exception.http_response.text == '{"errorMessage": "IAM error message"}'
+    assert exception.http_response.content == b'{"errorMessage": "IAM error message"}'
+    assert exception.http_response.json() == {'errorMessage': 'IAM error message'}
 
     responses.add(
         responses.GET,
@@ -86,3 +89,5 @@ def test_api_exception():
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'plain text error'
     assert str(exception) == 'Error: plain text error, Status code: 500 , X-global-transaction-id: xx'
+    assert exception.http_response.text == 'plain text error'
+    assert exception.http_response.content == b'plain text error'

--- a/test/test_jwt_token_manager.py
+++ b/test/test_jwt_token_manager.py
@@ -97,9 +97,8 @@ def test_is_token_expired():
 
 
 def test_abstract_class_instantiation():
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError, match=r"^Can't instantiate abstract class JWTTokenManager.*$"):
         JWTTokenManager(None)
-    assert str(err.value).startswith("Can't instantiate abstract class JWTTokenManager with abstract")
 
 
 def test_disable_ssl_verification():

--- a/test/test_token_manager.py
+++ b/test/test_token_manager.py
@@ -34,14 +34,8 @@ class MockTokenManager(TokenManager):
 
 
 def test_abstract_class_instantiation():
-    with pytest.raises(TypeError) as err:
+    with pytest.raises(TypeError, match=r"^Can't instantiate abstract class TokenManager.*$"):
         TokenManager(None)
-    assert (
-        str(err.value) == "Can't instantiate abstract class "
-        "TokenManager with abstract methods "
-        "_save_token_info, "
-        "request_token"
-    )
 
 
 def requests_request_spy(*args, **kwargs):


### PR DESCRIPTION
This commit makes some minor changes to a few testcases:
1. test_api_exception.py: add tests for some requests.Response operations

2. test_token_manager.py/test_jwt_token_manager.py: modified the abstract base class checks to work in Python 3.12 by matching only part of the error message that appears in the exception

3. I also added python 3.12 to the travis build definition since I found and fixed a couple of unit test errors when using python 3.12