### PR TITLE
build: ignore false-positive CVE

### DIFF
--- a/.cra/.cveignore
+++ b/.cra/.cveignore
@@ -1,0 +1,7 @@
+[
+    {
+        "cve": "CVE-2024-3651",
+	    "alwaysOmit": true,
+        "comment": "fixed version has been made, not yet updated in CRA-Clair: https://github.com/advisories/GHSA-jjg7-2v4v-x38h"
+    }
+]


### PR DESCRIPTION
This PR adds the .cveignore file to the repo to avoid the idna-related vulnerability that is currently being reported incorrectly by CRA.

Relates to this issue: https://github.ibm.com/arf/devx-scanner-issues/issues/15121