### PR TITLE
fix: remove `test` command and related code from `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import os
 import sys
 import pkg_resources
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 
 __version__ = '3.20.3'
 
@@ -36,22 +35,6 @@ with open('requirements.txt', encoding='utf-8') as f:
 with open('requirements-dev.txt', encoding='utf-8') as f:
     tests_require = [str(req) for req in pkg_resources.parse_requirements(f)]
 
-
-class PyTest(TestCommand):
-    """PyTest class."""
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = ['--strict', '--verbose', '--tb=long', 'test']
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-
-        errcode = pytest.main(self.test_args)
-        sys.exit(errcode)
-
-
 with open("README.md", "r", encoding='utf-8') as fh:
     readme = fh.read()
 
@@ -62,7 +45,6 @@ setup(
     license='Apache 2.0',
     install_requires=install_requires,
     tests_require=tests_require,
-    cmdclass={'test': PyTest},
     author='IBM',
     author_email='devxsdk@us.ibm.com',
     long_description=readme,


### PR DESCRIPTION
The `test` command and related function were deprecated for 5 years
and it seems the time has come: setuptools maintainers removed it
yesterday and that move has broken a bunch of Python packages
including this. After looking into several documentations and our source
code, I think the right thing to do - instead of making a workaround - is
**completely removing** it from our `setup.py` file as it hasn't been used for
a long time - correct me if I am wrong here and missed something!!
Some details:
- Issue in the `setuptools` repo: https://github.com/pypa/setuptools/issues/4519
- The commit that introduced this: https://github.com/pypa/setuptools/commit/4c0b9f3ee6ee47c597572655567f215c08c90137
- Release note: https://setuptools.pypa.io/en/stable/history.html#deprecations-and-removals
  > The test command has been removed. Users relying on 'setup.py test' will need to migrate to another test runner or pin setuptools before this version.
- Extra: https://docs.pytest.org/en/latest/explanation/goodpractices.html#do-not-run-via-setuptools
  > Integration with setuptools is **not recommended**, i.e. you should not be using `python setup.py test` or `pytest-runner`, and may stop working in the future.