### PR TITLE
feat(IamAssumeAuthenticator): introduce a new authenticator

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-10-08T13:48:47Z",
+  "generated_at": "2024-10-10T16:00:10Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -346,7 +346,7 @@
         "hashed_secret": "4080eeeaf54faf879b9e8d99c49a8503f7e855bb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 97,
+        "line_number": 17,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -354,7 +354,7 @@
         "hashed_secret": "37e94c31b6a756ba2afd2fe9a9765172cd79ac47",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 170,
+        "line_number": 102,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -362,7 +362,7 @@
         "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 191,
+        "line_number": 123,
         "type": "Hex High Entropy String",
         "verified_result": null
       }
@@ -372,8 +372,16 @@
         "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 55,
+        "line_number": 62,
         "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37e94c31b6a756ba2afd2fe9a9765172cd79ac47",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 205,
+        "type": "Secret Keyword",
         "verified_result": null
       }
     ],
@@ -504,7 +512,7 @@
         "hashed_secret": "34a0a47a51d5bf739df0214450385e29ee7e9847",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 439,
+        "line_number": 453,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -512,7 +520,7 @@
         "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 450,
+        "line_number": 464,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -520,7 +528,7 @@
         "hashed_secret": "2863fa4b5510c46afc2bd2998dfbc0cf3d6df032",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 545,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -528,7 +536,7 @@
         "hashed_secret": "b9cad336062c0dc3bb30145b1a6697fccfe755a6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 592,
+        "line_number": 606,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-09-16T18:49:02Z",
+  "generated_at": "2024-10-08T13:48:47Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,39 @@
         "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 65,
+        "line_number": 66,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "4f51cde3ac0a5504afa4bc06859b098366592c19",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 207,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "e87559ed7decb62d0733ae251ae58d42a55291d8",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 209,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "12f4a68ed3d0863e56497c9cdb1e2e4e91d5cb68",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 273,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "c837b75d7cd93ef9c2243ca28d6e5156259fd253",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 277,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -78,7 +110,7 @@
         "hashed_secret": "98635b2eaa2379f28cd6d72a38299f286b81b459",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 387,
+        "line_number": 502,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -86,7 +118,7 @@
         "hashed_secret": "47fcf185ee7e15fe05cae31fbe9e4ebe4a06a40d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 482,
+        "line_number": 597,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -96,7 +128,7 @@
         "hashed_secret": "fdee05598fdd57ff8e9ae29e92c25a04f2c52fa6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 31,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -147,6 +179,16 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 1,
+        "type": "Secret Keyword",
+        "verified_result": null
+      }
+    ],
+    "resources/ibm-credentials-iam-assume.env": [
+      {
+        "hashed_secret": "f2e7745f43b0ef0e2c2faf61d6c6a28be2965750",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 2,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -295,6 +337,42 @@
         "is_secret": false,
         "is_verified": false,
         "line_number": 48,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/test_iam_assume_authenticator.py": [
+      {
+        "hashed_secret": "4080eeeaf54faf879b9e8d99c49a8503f7e855bb",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 97,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "37e94c31b6a756ba2afd2fe9a9765172cd79ac47",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 170,
+        "type": "Secret Keyword",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 191,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/test_iam_assume_token_manager.py": [
+      {
+        "hashed_secret": "da2f27d2c57a0e1ed2dc3a34b4ef02faf2f7a4c2",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 55,
         "type": "Hex High Entropy String",
         "verified_result": null
       }

--- a/Authentication.md
+++ b/Authentication.md
@@ -235,7 +235,7 @@ specify the iam_account_id property as well.
 Exactly one of iam_profile_crn, iam_profile_id or iam_profile_name must be specified.
 
 - iam_account_id: (optional) the ID associated with the IAM account that contains the trusted profile
-referenced by the iam_profile_name property. The imaAccountId property must be specified if and only if
+referenced by the iam_profile_name property. The iam_account_id property must be specified if and only if
 the iam_profile_name property is specified.
 
 - url: (optional) The base endpoint URL of the IAM token service.
@@ -288,7 +288,7 @@ from ibm_cloud_sdk_core.authenticators import IAMAssumeAuthenticator
 from <sdk-package-name>.example_service_v1 import *
 
 # Create the authenticator.
-authenticator = IAMAssumeAuthenticator('myapikey')
+authenticator = IAMAssumeAuthenticator('myapikey', iam_profile_id='my_profile_id')
 
 # Construct the service instance.
 service = ExampleServiceV1(authenticator=authenticator)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ python -m pip install --upgrade ibm-cloud-sdk-core
 The python-sdk-core project supports the following types of authentication:
 - Basic Authentication
 - Bearer Token Authentication
-- Identity and Access Management (IAM) Authentication
+- Identity and Access Management (IAM) Authentication (grant type: apikey)
+- Identity and Access Management (IAM) Authentication (grant type: assume)
 - Container Authentication
 - VPC Instance Authentication
 - Cloud Pak for Data Authentication

--- a/ibm_cloud_sdk_core/__init__.py
+++ b/ibm_cloud_sdk_core/__init__.py
@@ -18,6 +18,7 @@ classes:
     BaseService: Abstract class for common functionality between each service.
     DetailedResponse: The object returned from successful service operations.
     IAMTokenManager: Requests and refreshes IAM tokens using an apikey, and optionally a client_id and client_secret.
+    IAMAssumeTokenManager: Requests and refreshes IAM tokens using an apikey and a trusted profile.
     JWTTokenManager: Abstract class for common functionality between each JWT token manager.
     CP4DTokenManager: Requests and refreshes CP4D tokens given a username and password.
     ApiException: Custom exception class for errors returned from service operations.
@@ -39,6 +40,7 @@ functions:
 from .base_service import BaseService
 from .detailed_response import DetailedResponse
 from .token_managers.iam_token_manager import IAMTokenManager
+from .token_managers.iam_assume_token_manager import IAMAssumeTokenManager
 from .token_managers.jwt_token_manager import JWTTokenManager
 from .token_managers.cp4d_token_manager import CP4DTokenManager
 from .token_managers.container_token_manager import ContainerTokenManager

--- a/ibm_cloud_sdk_core/authenticators/__init__.py
+++ b/ibm_cloud_sdk_core/authenticators/__init__.py
@@ -39,6 +39,7 @@ from .bearer_token_authenticator import BearerTokenAuthenticator
 from .container_authenticator import ContainerAuthenticator
 from .cp4d_authenticator import CloudPakForDataAuthenticator
 from .iam_authenticator import IAMAuthenticator
+from .iam_assume_authenticator import IAMAssumeAuthenticator
 from .vpc_instance_authenticator import VPCInstanceAuthenticator
 from .no_auth_authenticator import NoAuthAuthenticator
 from .mcsp_authenticator import MCSPAuthenticator

--- a/ibm_cloud_sdk_core/authenticators/authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/authenticator.py
@@ -24,6 +24,7 @@ class Authenticator(ABC):
     AUTHTYPE_BASIC = 'basic'
     AUTHTYPE_BEARERTOKEN = 'bearerToken'
     AUTHTYPE_IAM = 'iam'
+    AUTHTYPE_IAM_ASSUME = 'iamAssume'
     AUTHTYPE_CONTAINER = 'container'
     AUTHTYPE_CP4D = 'cp4d'
     AUTHTYPE_VPC = 'vpc'

--- a/ibm_cloud_sdk_core/authenticators/container_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/container_authenticator.py
@@ -66,6 +66,7 @@ class ContainerAuthenticator(IAMRequestBasedAuthenticator):
 
     def __init__(
         self,
+        *,
         cr_token_filename: Optional[str] = None,
         iam_profile_name: Optional[str] = None,
         iam_profile_id: Optional[str] = None,

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -42,12 +42,18 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         iam_profile_name: the name of the trusted profile (must be used together with `iam_account_id`)
         iam_account_id: the ID of the trusted profile (must be used together with `iam_profile_name`)
         url: The URL representing the IAM token service endpoint. If not specified, a suitable default value is used.
+        client_id: The client_id and client_secret fields are used to form
+            a "basic" authorization header for IAM token requests. Defaults to None.
+        client_secret: The client_id and client_secret fields are used to form
+            a "basic" authorization header for IAM token requests. Defaults to None.
         disable_ssl_verification: A flag that indicates whether verification of
             the server's SSL certificate should be disabled or not. Defaults to False.
         headers: Default headers to be sent with every IAM token request. Defaults to None.
         proxies: Dictionary for mapping request protocol to proxy URL. Defaults to None.
         proxies.http (optional): The proxy endpoint to use for HTTP requests.
         proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+        scope: The "scope" to use when fetching the bearer token from the IAM token server.
+            This can be used to obtain an access token with a specific scope.
 
     Attributes:
         token_manager (IAMTokenManager): Retrieves and manages IAM tokens from the endpoint specified by the url.
@@ -56,6 +62,7 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         TypeError: The `disable_ssl_verification` is not a bool.
         ValueError: The `apikey` is not valid for IAM token requests or the following keyword arguments are incorrectly specified:
             `iam_profile_id`, `iam_profile_crn`, `iam_profile_name`, `iam_account_id`,
+        ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
     """
 
     def __init__(
@@ -67,9 +74,12 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         iam_profile_name: Optional[str] = None,
         iam_account_id: Optional[str] = None,
         url: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
         disable_ssl_verification: bool = False,
         headers: Optional[Dict[str, str]] = None,
         proxies: Optional[Dict[str, str]] = None,
+        scope: Optional[str] = None,
     ) -> None:
         # Check the type of `disable_ssl_verification`. Must be a bool.
         if not isinstance(disable_ssl_verification, bool):
@@ -82,9 +92,12 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
             iam_profile_name=iam_profile_name,
             iam_account_id=iam_account_id,
             url=url,
+            client_id=client_id,
+            client_secret=client_secret,
             disable_ssl_verification=disable_ssl_verification,
             headers=headers,
             proxies=proxies,
+            scope=scope,
         )
 
         self.validate()

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -1,0 +1,158 @@
+# coding: utf-8
+
+# Copyright 2024 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Optional
+
+from ibm_cloud_sdk_core.token_managers.iam_assume_token_manager import IAMAssumeTokenManager
+
+from .authenticator import Authenticator
+from .iam_request_based_authenticator import IAMRequestBasedAuthenticator
+from ..utils import has_bad_first_or_last_char
+
+
+class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
+    """IAMAssumeAuthenticator obtains an IAM access token using the IAM "get-token" operation's
+    "assume" grant type. The authenticator obtains an initial IAM access token from a
+    user-supplied apikey, then exchanges this initial IAM access token for another IAM access token
+    that has "assumed the identity" of the specified trusted profile.
+
+    The bearer token will be sent as an Authorization header in the form:
+
+        Authorization: Bearer <bearer-token>
+
+    Args:
+        apikey: The IAM api key.
+
+    Keyword Args:
+        iam_profile_id: the ID of the trusted profile
+        iam_profile_crn: the CRN of the trusted profile
+        iam_profile_name: the name of the trusted profile (must be used together with `iam_account_id`)
+        iam_account_id: the ID of the trusted profile (must be used together with `iam_profile_name`)
+        url: The URL representing the IAM token service endpoint. If not specified, a suitable default value is used.
+        disable_ssl_verification: A flag that indicates whether verification of
+            the server's SSL certificate should be disabled or not. Defaults to False.
+        headers: Default headers to be sent with every IAM token request. Defaults to None.
+        proxies: Dictionary for mapping request protocol to proxy URL. Defaults to None.
+        proxies.http (optional): The proxy endpoint to use for HTTP requests.
+        proxies.https (optional): The proxy endpoint to use for HTTPS requests.
+
+    Attributes:
+        token_manager (IAMTokenManager): Retrieves and manages IAM tokens from the endpoint specified by the url.
+
+    Raises:
+        TypeError: The `disable_ssl_verification` is not a bool.
+        ValueError: The `apikey` is not valid for IAM token requests or the following keyword arguments are incorrectly specified:
+            `iam_profile_id`, `iam_profile_crn`, `iam_profile_name`, `iam_account_id`,
+    """
+
+    def __init__(
+        self,
+        apikey: str,
+        *,
+        iam_profile_id: Optional[str] = None,
+        iam_profile_crn: Optional[str] = None,
+        iam_profile_name: Optional[str] = None,
+        iam_account_id: Optional[str] = None,
+        url: Optional[str] = None,
+        disable_ssl_verification: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        proxies: Optional[Dict[str, str]] = None,
+    ) -> None:
+        # Check the type of `disable_ssl_verification`. Must be a bool.
+        if not isinstance(disable_ssl_verification, bool):
+            raise TypeError('disable_ssl_verification must be a bool')
+
+        self.token_manager = IAMAssumeTokenManager(
+            apikey,
+            iam_profile_id=iam_profile_id,
+            iam_profile_crn=iam_profile_crn,
+            iam_profile_name=iam_profile_name,
+            iam_account_id=iam_account_id,
+            url=url,
+            disable_ssl_verification=disable_ssl_verification,
+            headers=headers,
+            proxies=proxies,
+        )
+
+        self.validate()
+
+    def authentication_type(self) -> str:
+        """Returns this authenticator's type ('iamAssume')."""
+        return Authenticator.AUTHTYPE_IAM_ASSUME
+
+    def validate(self) -> None:
+        """Validates the provided IAM related arguments.
+
+        Ensure the following:
+        - `apikey` of the IAMTokenManager is not `None`, and has no bad characters
+        - both `client_id` and `client_secret` are set if either of them are defined
+        - the correct number and type of IAM profile and IAM account options are specified
+
+        Raises:
+            ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
+        """
+        super().validate()
+
+        if self.token_manager.iam_delegate.apikey is None:
+            raise ValueError('The apikey shouldn\'t be None.')
+
+        if has_bad_first_or_last_char(self.token_manager.iam_delegate.apikey):
+            raise ValueError(
+                'The apikey shouldn\'t start or end with curly brackets or quotes. '
+                'Please remove any surrounding {, }, or \" characters.'
+            )
+
+        # Only one of the following arguments must be specified.
+        mutually_exclusive_attributes = [
+            self.token_manager.iam_profile_id,
+            self.token_manager.iam_profile_crn,
+            self.token_manager.iam_profile_name,
+        ]
+        if list(map(bool, mutually_exclusive_attributes)).count(True) != 1:
+            raise ValueError(
+                'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
+            )
+
+        # `iam_account_id` must be specified iff `iam_profile_name` is used.
+        if self.token_manager.iam_profile_name and not self.token_manager.iam_account_id:
+            raise ValueError('`iam_profile_name` and `iam_account_id` must be provided together, or not at all.')
+
+    def set_iam_profile_id(self, iam_profile_id: str) -> None:
+        """Set the ID of the IAM profile.
+
+        Args:
+            iam_profile_id (str): the ID of the IAM profile.
+        """
+        self.token_manager.iam_profile_id = iam_profile_id
+
+    def set_iam_profile_crn(self, iam_profile_crn: str) -> None:
+        """Set the CRN of the IAM profile.
+
+        Args:
+            iam_profile_crn (str): the CRN of the IAM profile.
+        """
+        self.token_manager.iam_profile_crn = iam_profile_crn
+
+    def set_iam_profile_name_and_account_id(self, iam_profile_name: str, iam_account_id: str) -> None:
+        """Set both the name of the IAM profile and the IAM account ID that the profile belongs to.
+
+        Args:
+            iam_profile_name (str): name of the IAM profile.
+            iam_account_id (str): ID of the IAM account.
+        """
+        self.token_manager.iam_profile_name = iam_profile_name
+        self.token_manager.iam_account_id = iam_account_id
+        self.validate()

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -16,6 +16,7 @@
 
 from typing import Any, Dict, Optional
 
+from ibm_cloud_sdk_core.authenticators.iam_authenticator import IAMAuthenticator
 from ibm_cloud_sdk_core.token_managers.iam_assume_token_manager import IAMAssumeTokenManager
 
 from .authenticator import Authenticator
@@ -127,14 +128,11 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         """
         super().validate()
 
-        if self.token_manager.iam_delegate.apikey is None:
-            raise ValueError('The apikey shouldn\'t be None.')
-
-        if has_bad_first_or_last_char(self.token_manager.iam_delegate.apikey):
-            raise ValueError(
-                'The apikey shouldn\'t start or end with curly brackets or quotes. '
-                'Please remove any surrounding {, }, or \" characters.'
-            )
+        # Create a temporary IAM authenticator that we can use to validat our delegate.
+        tmp_authenticator = IAMAuthenticator("")
+        tmp_authenticator.token_manager = self.token_manager.iam_delegate
+        tmp_authenticator.validate()
+        del tmp_authenticator
 
         # Only one of the following arguments must be specified.
         mutually_exclusive_attributes = [

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -106,7 +106,7 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
     def __getattribute__(self, name: str) -> Any:
         disallowed_attrs = ['set_scope', 'set_client_id_and_secret']
         if name in disallowed_attrs:
-            raise AttributeError(f"'IAMAssumeAuthenticator' has no attribute '{name}'")
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
 
         return super().__getattribute__(name)
 

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from ibm_cloud_sdk_core.token_managers.iam_assume_token_manager import IAMAssumeTokenManager
 
@@ -60,9 +60,9 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
 
     Raises:
         TypeError: The `disable_ssl_verification` is not a bool.
-        ValueError: The `apikey` is not valid for IAM token requests or the following keyword arguments are incorrectly specified:
-            `iam_profile_id`, `iam_profile_crn`, `iam_profile_name`, `iam_account_id`,
-        ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
+        ValueError: The `apikey`, `client_id`, and/or `client_secret` are not valid for IAM token requests or the
+            following keyword arguments are incorrectly specified:
+            `iam_profile_id`, `iam_profile_crn`, `iam_profile_name`, `iam_account_id`.
     """
 
     def __init__(
@@ -101,6 +101,14 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         )
 
         self.validate()
+
+    # Disable a few methods, inherited from the parent class.
+    def __getattribute__(self, name: str) -> Any:
+        disallowed_attrs = ['set_scope', 'set_client_id_and_secret']
+        if name in disallowed_attrs:
+            raise AttributeError(f"'IAMAssumeAuthenticator' has no attribute '{name}'")
+
+        return super().__getattribute__(name)
 
     def authentication_type(self) -> str:
         """Returns this authenticator's type ('iamAssume')."""

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -151,6 +151,10 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         if self.token_manager.iam_profile_name and not self.token_manager.iam_account_id:
             raise ValueError('`iam_profile_name` and `iam_account_id` must be provided together, or not at all.')
 
+    def set_disable_ssl_verification(self, status: bool = False) -> None:
+        self.token_manager.iam_delegate.set_disable_ssl_verification(status)
+        return super().set_disable_ssl_verification(status)
+
     def set_iam_profile_id(self, iam_profile_id: str) -> None:
         """Set the ID of the IAM profile.
 

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -21,7 +21,6 @@ from ibm_cloud_sdk_core.token_managers.iam_assume_token_manager import IAMAssume
 
 from .authenticator import Authenticator
 from .iam_request_based_authenticator import IAMRequestBasedAuthenticator
-from ..utils import has_bad_first_or_last_char
 
 
 class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
@@ -103,10 +102,9 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
 
         self.validate()
 
-    # Disable a few methods, inherited from the parent class.
+    # Disable all setter methods, inherited from the parent class.
     def __getattribute__(self, name: str) -> Any:
-        disallowed_attrs = ['set_scope', 'set_client_id_and_secret']
-        if name in disallowed_attrs:
+        if name.startswith("set_"):
             raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
 
         return super().__getattribute__(name)
@@ -146,34 +144,3 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         # `iam_account_id` must be specified iff `iam_profile_name` is used.
         if self.token_manager.iam_profile_name and not self.token_manager.iam_account_id:
             raise ValueError('`iam_profile_name` and `iam_account_id` must be provided together, or not at all.')
-
-    def set_disable_ssl_verification(self, status: bool = False) -> None:
-        self.token_manager.iam_delegate.set_disable_ssl_verification(status)
-        return super().set_disable_ssl_verification(status)
-
-    def set_iam_profile_id(self, iam_profile_id: str) -> None:
-        """Set the ID of the IAM profile.
-
-        Args:
-            iam_profile_id (str): the ID of the IAM profile.
-        """
-        self.token_manager.iam_profile_id = iam_profile_id
-
-    def set_iam_profile_crn(self, iam_profile_crn: str) -> None:
-        """Set the CRN of the IAM profile.
-
-        Args:
-            iam_profile_crn (str): the CRN of the IAM profile.
-        """
-        self.token_manager.iam_profile_crn = iam_profile_crn
-
-    def set_iam_profile_name_and_account_id(self, iam_profile_name: str, iam_account_id: str) -> None:
-        """Set both the name of the IAM profile and the IAM account ID that the profile belongs to.
-
-        Args:
-            iam_profile_name (str): name of the IAM profile.
-            iam_account_id (str): ID of the IAM account.
-        """
-        self.token_manager.iam_profile_name = iam_profile_name
-        self.token_manager.iam_account_id = iam_account_id
-        self.validate()

--- a/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_assume_authenticator.py
@@ -126,9 +126,7 @@ class IAMAssumeAuthenticator(IAMRequestBasedAuthenticator):
         Raises:
             ValueError: The apikey, client_id, and/or client_secret are not valid for IAM token requests.
         """
-        super().validate()
-
-        # Create a temporary IAM authenticator that we can use to validat our delegate.
+        # Create a temporary IAM authenticator that we can use to validate our delegate.
         tmp_authenticator = IAMAuthenticator("")
         tmp_authenticator.token_manager = self.token_manager.iam_delegate
         tmp_authenticator.validate()

--- a/ibm_cloud_sdk_core/base_service.py
+++ b/ibm_cloud_sdk_core/base_service.py
@@ -508,4 +508,4 @@ class BaseService:
 
     @staticmethod
     def _encode_path_vars(*args) -> None:
-        return (requests.utils.quote(x, safe='') for x in args)
+        return BaseService.encode_path_vars(*args)

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -21,6 +21,7 @@ from .authenticators import (
     ContainerAuthenticator,
     CloudPakForDataAuthenticator,
     IAMAuthenticator,
+    IAMAssumeAuthenticator,
     NoAuthAuthenticator,
     VPCInstanceAuthenticator,
     MCSPAuthenticator,
@@ -55,6 +56,7 @@ def get_authenticator_from_environment(service_name: str) -> Authenticator:
     return authenticator
 
 
+# pylint: disable=too-many-branches
 def __construct_authenticator(config: dict) -> Authenticator:
     # Determine the authentication type if not specified explicitly.
     if config.get('AUTH_TYPE'):
@@ -103,6 +105,16 @@ def __construct_authenticator(config: dict) -> Authenticator:
             client_secret=config.get('CLIENT_SECRET'),
             disable_ssl_verification=config.get('AUTH_DISABLE_SSL', 'false').lower() == 'true',
             scope=config.get('SCOPE'),
+        )
+    elif auth_type == Authenticator.AUTHTYPE_IAM_ASSUME.lower():
+        authenticator = IAMAssumeAuthenticator(
+            apikey=config.get('APIKEY'),
+            iam_profile_id=config.get('IAM_PROFILE_ID'),
+            iam_profile_crn=config.get('IAM_PROFILE_CRN'),
+            iam_profile_name=config.get('IAM_PROFILE_NAME'),
+            iam_account_id=config.get('IAM_ACCOUNT_ID'),
+            url=config.get('AUTH_URL'),
+            disable_ssl_verification=config.get('AUTH_DISABLE_SSL', 'false').lower() == 'true',
         )
     elif auth_type == Authenticator.AUTHTYPE_VPC.lower():
         authenticator = VPCInstanceAuthenticator(

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -114,7 +114,10 @@ def __construct_authenticator(config: dict) -> Authenticator:
             iam_profile_name=config.get('IAM_PROFILE_NAME'),
             iam_account_id=config.get('IAM_ACCOUNT_ID'),
             url=config.get('AUTH_URL'),
+            client_id=config.get('CLIENT_ID'),
+            client_secret=config.get('CLIENT_SECRET'),
             disable_ssl_verification=config.get('AUTH_DISABLE_SSL', 'false').lower() == 'true',
+            scope=config.get('SCOPE'),
         )
     elif auth_type == Authenticator.AUTHTYPE_VPC.lower():
         authenticator = VPCInstanceAuthenticator(

--- a/ibm_cloud_sdk_core/token_managers/container_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/container_token_manager.py
@@ -85,6 +85,7 @@ class ContainerTokenManager(IAMRequestBasedTokenManager):
 
     def __init__(
         self,
+        *,
         cr_token_filename: Optional[str] = None,
         iam_profile_name: Optional[str] = None,
         iam_profile_id: Optional[str] = None,

--- a/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
@@ -1,0 +1,117 @@
+# coding: utf-8
+
+# Copyright 2024 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Optional
+
+from ibm_cloud_sdk_core.token_managers.iam_token_manager import IAMTokenManager
+
+from .iam_request_based_token_manager import IAMRequestBasedTokenManager
+from ..private_helpers import _build_user_agent
+
+
+class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
+    """The IAMTokenManager takes an api key and information about a trusted profile then performs the necessary
+    interactions with the IAM token service to obtain and store a suitable bearer token. This token "assumes" the
+    identity of the provided trusted profile.
+
+    Attributes:
+        iam_profile_id (str): the ID of the trusted profile
+        iam_profile_crn (str): the CRN of the trusted profile
+        iam_profile_name (str): the name of the trusted profile (must be used together with `iam_account_id`)
+        iam_account_id (str): the ID of the trusted profile (must be used together with `iam_profile_name`)
+        iam_deletgate (IAMTokenManager): an IAMTokenManager instance used to obtain the user's IAM access token from the `apikey`.
+        url (str): The IAM endpoint to token requests.
+        headers (dict): Default headers to be sent with every IAM token request.
+        proxies (dict): Proxies to use for communicating with IAM.
+        proxies.http (str): The proxy endpoint to use for HTTP requests.
+        proxies.https (str): The proxy endpoint to use for HTTPS requests.
+        http_config (dict): A dictionary containing values that control the timeout, proxies, and etc of HTTP requests.
+
+    Args:
+        apikey: A generated APIKey from IBM Cloud.
+
+    Keyword Args:
+        iam_profile_id: the ID of the trusted profile
+        iam_profile_crn: the CRN of the trusted profile
+        iam_profile_name: the name of the trusted profile (must be used together with `iam_account_id`)
+        iam_account_id: the ID of the trusted profile (must be used together with `iam_profile_name`)
+        url: The IAM endpoint to token requests. Defaults to None.
+        disable_ssl_verification: A flag that indicates whether verification of
+            the server's SSL certificate should be disabled or not. Defaults to False.
+        headers: Default headers to be sent with every IAM token request. Defaults to None.
+        proxies: Proxies to use for communicating with IAM. Defaults to None.
+        proxies.http: The proxy endpoint to use for HTTP requests.
+        proxies.https: The proxy endpoint to use for HTTPS requests.
+    """
+
+    def __init__(
+        self,
+        apikey: str,
+        *,
+        iam_profile_id: Optional[str] = None,
+        iam_profile_crn: Optional[str] = None,
+        iam_profile_name: Optional[str] = None,
+        iam_account_id: Optional[str] = None,
+        url: Optional[str] = None,
+        disable_ssl_verification: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        proxies: Optional[Dict[str, str]] = None,
+    ) -> None:
+        super().__init__(
+            url=url,
+            disable_ssl_verification=disable_ssl_verification,
+            headers=headers,
+            proxies=proxies,
+        )
+
+        self.iam_profile_id = iam_profile_id
+        self.iam_profile_crn = iam_profile_crn
+        self.iam_profile_name = iam_profile_name
+        self.iam_account_id = iam_account_id
+
+        # Create an IAMTokenManager instance that will be used to obtain an IAM access token
+        # for the IAM "assume" token exchange. We use the same configuration that's provided
+        # for this class, as they have a lot in common.
+        self.iam_delegate = IAMTokenManager(
+            apikey=apikey,
+            url=url,
+            disable_ssl_verification=disable_ssl_verification,
+            headers=headers,
+            proxies=proxies,
+        )
+
+        self.request_payload['grant_type'] = 'urn:ibm:params:oauth:grant-type:assume'
+        self._set_user_agent(_build_user_agent('iam-assume-authenticator'))
+
+    def request_token(self) -> Dict:
+        """Retrieves a standard IAM access token by using the IAM token manager
+        then obtains another access token for the assumed identity.
+
+        Returns:
+            A dictionary that contains the access token of the assumed IAM identity.
+        """
+        # Fetch the user's original IAM access token before trying to assume.
+        self.request_payload['access_token'] = self.iam_delegate.get_token()
+
+        if self.iam_profile_crn:
+            self.request_payload['profile_crn'] = self.iam_profile_crn
+        if self.iam_profile_id:
+            self.request_payload['profile_id'] = self.iam_profile_id
+        else:
+            self.request_payload['profile_name'] = self.iam_profile_name
+            self.request_payload['account'] = self.iam_account_id
+
+        return super().request_token()

--- a/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from ibm_cloud_sdk_core.token_managers.iam_token_manager import IAMTokenManager
 
@@ -111,6 +111,13 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
 
         self.request_payload['grant_type'] = 'urn:ibm:params:oauth:grant-type:assume'
         self._set_user_agent(_build_user_agent('iam-assume-authenticator'))
+
+    # Disable all setter methods, inherited from the parent class.
+    def __getattribute__(self, name: str) -> Any:
+        if name.startswith("set_"):
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
+
+        return super().__getattribute__(name)
 
     def request_token(self) -> Dict:
         """Retrieves a standard IAM access token by using the IAM token manager

--- a/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
@@ -32,7 +32,8 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
         iam_profile_crn (str): the CRN of the trusted profile
         iam_profile_name (str): the name of the trusted profile (must be used together with `iam_account_id`)
         iam_account_id (str): the ID of the trusted profile (must be used together with `iam_profile_name`)
-        iam_deletgate (IAMTokenManager): an IAMTokenManager instance used to obtain the user's IAM access token from the `apikey`.
+        iam_deletgate (IAMTokenManager): an IAMTokenManager instance used to obtain the user's IAM access token
+            from the `apikey`.
         url (str): The IAM endpoint to token requests.
         headers (dict): Default headers to be sent with every IAM token request.
         proxies (dict): Proxies to use for communicating with IAM.
@@ -62,7 +63,7 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
         proxies.http: The proxy endpoint to use for HTTP requests.
         proxies.https: The proxy endpoint to use for HTTPS requests.
         scope: The "scope" to use when fetching the bearer token from the IAM token server.
-        This can be used to obtain an access token with a specific scope.
+            This can be used to obtain an access token with a specific scope.
     """
 
     def __init__(

--- a/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
@@ -49,12 +49,20 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
         iam_profile_name: the name of the trusted profile (must be used together with `iam_account_id`)
         iam_account_id: the ID of the trusted profile (must be used together with `iam_profile_name`)
         url: The IAM endpoint to token requests. Defaults to None.
+        client_id: The client_id and client_secret fields are used to form
+            a "basic auth" Authorization header for interactions with the IAM token server.
+            Defaults to None.
+        client_secret: The client_id and client_secret fields are used to form
+            a "basic auth" Authorization header for interactions with the IAM token server.
+            Defaults to None.
         disable_ssl_verification: A flag that indicates whether verification of
             the server's SSL certificate should be disabled or not. Defaults to False.
         headers: Default headers to be sent with every IAM token request. Defaults to None.
         proxies: Proxies to use for communicating with IAM. Defaults to None.
         proxies.http: The proxy endpoint to use for HTTP requests.
         proxies.https: The proxy endpoint to use for HTTPS requests.
+        scope: The "scope" to use when fetching the bearer token from the IAM token server.
+        This can be used to obtain an access token with a specific scope.
     """
 
     def __init__(
@@ -66,15 +74,21 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
         iam_profile_name: Optional[str] = None,
         iam_account_id: Optional[str] = None,
         url: Optional[str] = None,
+        client_id: Optional[str] = None,
+        client_secret: Optional[str] = None,
         disable_ssl_verification: bool = False,
         headers: Optional[Dict[str, str]] = None,
         proxies: Optional[Dict[str, str]] = None,
+        scope: Optional[str] = None,
     ) -> None:
         super().__init__(
             url=url,
+            client_id=client_id,
+            client_secret=client_secret,
             disable_ssl_verification=disable_ssl_verification,
             headers=headers,
             proxies=proxies,
+            scope=scope,
         )
 
         self.iam_profile_id = iam_profile_id
@@ -88,9 +102,12 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
         self.iam_delegate = IAMTokenManager(
             apikey=apikey,
             url=url,
+            client_id=client_id,
+            client_secret=client_secret,
             disable_ssl_verification=disable_ssl_verification,
             headers=headers,
             proxies=proxies,
+            scope=scope,
         )
 
         self.request_payload['grant_type'] = 'urn:ibm:params:oauth:grant-type:assume'

--- a/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from ibm_cloud_sdk_core.token_managers.iam_token_manager import IAMTokenManager
 
@@ -113,6 +113,14 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
 
         self.request_payload['grant_type'] = 'urn:ibm:params:oauth:grant-type:assume'
         self._set_user_agent(_build_user_agent('iam-assume-authenticator'))
+
+    # Remove unsupported attributes, inherited from the parent class.
+    def __getattribute__(self, name: str) -> Any:
+        disallowed_attrs = ['refresh_token', 'client_id', 'client_secret']
+        if name in disallowed_attrs:
+            raise AttributeError(f"'{self.__class__.__name__}' has no attribute '{name}'")
+
+        return super().__getattribute__(name)
 
     def request_token(self) -> Dict:
         """Retrieves a standard IAM access token by using the IAM token manager

--- a/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_assume_token_manager.py
@@ -23,7 +23,7 @@ from ..private_helpers import _build_user_agent
 
 
 class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
-    """The IAMTokenManager takes an api key and information about a trusted profile then performs the necessary
+    """The IAMAssumeTokenManager takes an api key and information about a trusted profile then performs the necessary
     interactions with the IAM token service to obtain and store a suitable bearer token. This token "assumes" the
     identity of the provided trusted profile.
 
@@ -32,7 +32,7 @@ class IAMAssumeTokenManager(IAMRequestBasedTokenManager):
         iam_profile_crn (str): the CRN of the trusted profile
         iam_profile_name (str): the name of the trusted profile (must be used together with `iam_account_id`)
         iam_account_id (str): the ID of the trusted profile (must be used together with `iam_profile_name`)
-        iam_deletgate (IAMTokenManager): an IAMTokenManager instance used to obtain the user's IAM access token
+        iam_delegate (IAMTokenManager): an IAMTokenManager instance used to obtain the user's IAM access token
             from the `apikey`.
         url (str): The IAM endpoint to token requests.
         headers (dict): Default headers to be sent with every IAM token request.

--- a/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/iam_request_based_token_manager.py
@@ -70,6 +70,7 @@ class IAMRequestBasedTokenManager(JWTTokenManager):
 
     def __init__(
         self,
+        *,
         url: Optional[str] = None,
         client_id: Optional[str] = None,
         client_secret: Optional[str] = None,

--- a/resources/ibm-credentials-iam-assume.env
+++ b/resources/ibm-credentials-iam-assume.env
@@ -1,0 +1,5 @@
+SERVICE_1_AUTH_TYPE=iamAssume
+SERVICE_1_APIKEY=my-api-key
+SERVICE_1_IAM_PROFILE_ID=iam-profile-1
+SERVICE_1_URL=https://iamhost/iamassume/api
+SERVICE_1_DISABLE_SSL=True

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -19,3 +19,5 @@ def test_authenticator():
     authenticator = TestAuthenticator()
     assert authenticator is not None
     assert authenticator.authentication_type() == Authenticator.AUTHTYPE_UNKNOWN
+    assert authenticator.validate() is None
+    assert authenticator.authenticate(None) is None

--- a/test/test_container_authenticator.py
+++ b/test/test_container_authenticator.py
@@ -84,7 +84,7 @@ def test_container_authenticator_with_scope():
 
 def test_authenticator_validate_failed():
     with pytest.raises(ValueError) as err:
-        ContainerAuthenticator(None)
+        ContainerAuthenticator()
     assert str(err.value) == 'At least one of iam_profile_name or iam_profile_id must be specified.'
 
     with pytest.raises(ValueError) as err:

--- a/test/test_container_token_manager.py
+++ b/test/test_container_token_manager.py
@@ -165,6 +165,32 @@ def test_retrieve_cr_token_success():
     assert cr_token == 'cr-token-1'
 
 
+def test_retrieve_cr_token_with_no_filename_1_success():
+    token_manager = ContainerTokenManager()
+
+    # Override the constants with the default locations
+    # just for testing purposes.
+    setattr(token_manager, 'DEFAULT_CR_TOKEN_FILENAME1', cr_token_file)
+    setattr(token_manager, 'DEFAULT_CR_TOKEN_FILENAME2', '')
+
+    cr_token = token_manager.retrieve_cr_token()
+
+    assert cr_token == 'cr-token-1'
+
+
+def test_retrieve_cr_token_with_no_filename_2_success():
+    token_manager = ContainerTokenManager()
+
+    # Override the constants with the default locations
+    # just for testing purposes.
+    setattr(token_manager, 'DEFAULT_CR_TOKEN_FILENAME1', '')
+    setattr(token_manager, 'DEFAULT_CR_TOKEN_FILENAME2', cr_token_file)
+
+    cr_token = token_manager.retrieve_cr_token()
+
+    assert cr_token == 'cr-token-1'
+
+
 def test_retrieve_cr_token_fail():
     token_manager = ContainerTokenManager(
         cr_token_filename='bogus-cr-token-file',

--- a/test/test_iam_assume_authenticator.py
+++ b/test/test_iam_assume_authenticator.py
@@ -31,6 +31,14 @@ def test_iam_assume_authenticator():
     assert authenticator.token_manager.scope is None
 
 
+def test_iam_assume_authenticator_disable_ssl_wrong_type():
+    with pytest.raises(TypeError) as err:
+        IAMAssumeAuthenticator(
+            apikey='my_apikey', iam_profile_crn='crn:iam-profile:123', disable_ssl_verification='yes'
+        )
+    assert str(err.value) == 'disable_ssl_verification must be a bool'
+
+
 def test_iam_assume_authenticator_validate_failed():
     with pytest.raises(ValueError) as err:
         IAMAssumeAuthenticator(None)

--- a/test/test_iam_assume_authenticator.py
+++ b/test/test_iam_assume_authenticator.py
@@ -43,13 +43,6 @@ def test_iam_assume_authenticator():
     assert authenticator.token_manager.iam_profile_name == 'my-profile-name'
     assert authenticator.token_manager.iam_account_id == 'my-acc-id'
 
-    authenticator.set_client_id_and_secret('tom', 'jerry')
-    assert authenticator.token_manager.client_id == 'tom'
-    assert authenticator.token_manager.client_secret == 'jerry'
-
-    authenticator.set_scope('scope1 scope2 scope3')
-    assert authenticator.token_manager.scope == 'scope1 scope2 scope3'
-
     with pytest.raises(TypeError) as err:
         authenticator.set_headers('dummy')
     assert str(err.value) == 'headers must be a dictionary'
@@ -218,3 +211,13 @@ def test_multiple_iam_assume_authenticators():
     authenticator_2 = IAMAssumeAuthenticator('my_other_apikey', iam_profile_id='my_profile_id_2')
     assert authenticator_2.token_manager.iam_delegate.request_payload['apikey'] == 'my_other_apikey'
     assert authenticator_1.token_manager.iam_delegate.request_payload['apikey'] == 'my_apikey'
+
+
+def test_iam_assume_authenticator_unsupported_methods():
+    authenticator = IAMAssumeAuthenticator('my_apikey', iam_profile_id='my_profile_id')
+    with pytest.raises(AttributeError) as err:
+        authenticator.set_scope('my_scope')
+    assert str(err.value) == "'IAMAssumeAuthenticator' has no attribute 'set_scope'"
+    with pytest.raises(AttributeError) as err:
+        authenticator.set_client_id_and_secret('my_client_id', 'my_client_secret')
+    assert str(err.value) == "'IAMAssumeAuthenticator' has no attribute 'set_client_id_and_secret'"

--- a/test/test_iam_assume_authenticator.py
+++ b/test/test_iam_assume_authenticator.py
@@ -30,63 +30,6 @@ def test_iam_assume_authenticator():
     assert authenticator.token_manager.iam_account_id is None
     assert authenticator.token_manager.scope is None
 
-    authenticator.set_iam_profile_id('my-id-123')
-    assert authenticator.token_manager.iam_profile_id == 'my-id-123'
-
-    authenticator.set_iam_profile_crn('crn:iam-profile:456')
-    assert authenticator.token_manager.iam_profile_crn == 'crn:iam-profile:456'
-
-    # We need to unset the other IAM related attributes to avoid validation error.
-    authenticator.set_iam_profile_id(None)
-    authenticator.set_iam_profile_crn(None)
-    authenticator.set_iam_profile_name_and_account_id('my-profile-name', 'my-acc-id')
-    assert authenticator.token_manager.iam_profile_name == 'my-profile-name'
-    assert authenticator.token_manager.iam_account_id == 'my-acc-id'
-
-    with pytest.raises(TypeError) as err:
-        authenticator.set_headers('dummy')
-    assert str(err.value) == 'headers must be a dictionary'
-
-    authenticator.set_headers({'dummy': 'headers'})
-    assert authenticator.token_manager.headers == {'dummy': 'headers'}
-
-    with pytest.raises(TypeError) as err:
-        authenticator.set_proxies('dummy')
-    assert str(err.value) == 'proxies must be a dictionary'
-
-    authenticator.set_proxies({'dummy': 'proxies'})
-    assert authenticator.token_manager.proxies == {'dummy': 'proxies'}
-
-    authenticator.set_disable_ssl_verification(True)
-    assert authenticator.token_manager.disable_ssl_verification
-
-
-def test_disable_ssl_verification():
-    authenticator = IAMAssumeAuthenticator(
-        apikey='my_apikey', iam_profile_id='my-profile-id', disable_ssl_verification=True
-    )
-    assert authenticator.token_manager.disable_ssl_verification is True
-    assert authenticator.token_manager.iam_delegate.disable_ssl_verification is True
-
-    authenticator.set_disable_ssl_verification(False)
-    assert authenticator.token_manager.disable_ssl_verification is False
-    assert authenticator.token_manager.iam_delegate.disable_ssl_verification is False
-
-
-def test_invalid_disable_ssl_verification_type():
-    with pytest.raises(TypeError) as err:
-        authenticator = IAMAssumeAuthenticator(
-            apikey='my_apikey', iam_profile_id='my-profile-id', disable_ssl_verification='True'
-        )
-    assert str(err.value) == 'disable_ssl_verification must be a bool'
-
-    authenticator = IAMAssumeAuthenticator(apikey='my_apikey', iam_profile_id='my-profile-id')
-    assert authenticator.token_manager.disable_ssl_verification is False
-
-    with pytest.raises(TypeError) as err:
-        authenticator.set_disable_ssl_verification('True')
-    assert str(err.value) == 'status must be a bool'
-
 
 def test_iam_assume_authenticator_validate_failed():
     with pytest.raises(ValueError) as err:
@@ -217,9 +160,23 @@ def test_multiple_iam_assume_authenticators():
 
 def test_iam_assume_authenticator_unsupported_methods():
     authenticator = IAMAssumeAuthenticator('my_apikey', iam_profile_id='my_profile_id')
+
     with pytest.raises(AttributeError) as err:
         authenticator.set_scope('my_scope')
     assert str(err.value) == "'IAMAssumeAuthenticator' has no attribute 'set_scope'"
+
     with pytest.raises(AttributeError) as err:
         authenticator.set_client_id_and_secret('my_client_id', 'my_client_secret')
     assert str(err.value) == "'IAMAssumeAuthenticator' has no attribute 'set_client_id_and_secret'"
+
+    with pytest.raises(AttributeError) as err:
+        authenticator.set_headers({})
+    assert str(err.value) == "'IAMAssumeAuthenticator' has no attribute 'set_headers'"
+
+    with pytest.raises(AttributeError) as err:
+        authenticator.set_proxies({})
+    assert str(err.value) == "'IAMAssumeAuthenticator' has no attribute 'set_proxies'"
+
+    with pytest.raises(AttributeError) as err:
+        authenticator.set_disable_ssl_verification(True)
+    assert str(err.value) == "'IAMAssumeAuthenticator' has no attribute 'set_disable_ssl_verification'"

--- a/test/test_iam_assume_authenticator.py
+++ b/test/test_iam_assume_authenticator.py
@@ -18,6 +18,8 @@ def test_iam_assume_authenticator():
     assert authenticator is not None
     assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM_ASSUME
     assert authenticator.token_manager.url == 'https://iam.cloud.ibm.com'
+    assert authenticator.token_manager.client_id is None
+    assert authenticator.token_manager.client_secret is None
     assert authenticator.token_manager.disable_ssl_verification is False
     assert authenticator.token_manager.headers is None
     assert authenticator.token_manager.proxies is None
@@ -26,6 +28,7 @@ def test_iam_assume_authenticator():
     assert authenticator.token_manager.iam_profile_crn == 'crn:iam-profile:123'
     assert authenticator.token_manager.iam_profile_name is None
     assert authenticator.token_manager.iam_account_id is None
+    assert authenticator.token_manager.scope is None
 
     authenticator.set_iam_profile_id('my-id-123')
     assert authenticator.token_manager.iam_profile_id == 'my-id-123'
@@ -39,6 +42,13 @@ def test_iam_assume_authenticator():
     authenticator.set_iam_profile_name_and_account_id('my-profile-name', 'my-acc-id')
     assert authenticator.token_manager.iam_profile_name == 'my-profile-name'
     assert authenticator.token_manager.iam_account_id == 'my-acc-id'
+
+    authenticator.set_client_id_and_secret('tom', 'jerry')
+    assert authenticator.token_manager.client_id == 'tom'
+    assert authenticator.token_manager.client_secret == 'jerry'
+
+    authenticator.set_scope('scope1 scope2 scope3')
+    assert authenticator.token_manager.scope == 'scope1 scope2 scope3'
 
     with pytest.raises(TypeError) as err:
         authenticator.set_headers('dummy')
@@ -145,6 +155,14 @@ def test_iam_assume_authenticator_validate_failed():
     assert (
         str(err.value) == 'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
     )
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('my_apikey', client_id='my_client_id')
+    assert str(err.value) == 'Both client_id and client_secret should be initialized.'
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('my_apikey', client_secret='my_client_secret')
+    assert str(err.value) == 'Both client_id and client_secret should be initialized.'
 
 
 @responses.activate

--- a/test/test_iam_assume_authenticator.py
+++ b/test/test_iam_assume_authenticator.py
@@ -66,9 +66,11 @@ def test_disable_ssl_verification():
         apikey='my_apikey', iam_profile_id='my-profile-id', disable_ssl_verification=True
     )
     assert authenticator.token_manager.disable_ssl_verification is True
+    assert authenticator.token_manager.iam_delegate.disable_ssl_verification is True
 
     authenticator.set_disable_ssl_verification(False)
     assert authenticator.token_manager.disable_ssl_verification is False
+    assert authenticator.token_manager.iam_delegate.disable_ssl_verification is False
 
 
 def test_invalid_disable_ssl_verification_type():

--- a/test/test_iam_assume_authenticator.py
+++ b/test/test_iam_assume_authenticator.py
@@ -1,0 +1,202 @@
+# pylint: disable=missing-docstring
+import logging
+import json
+import time
+
+import jwt
+import pytest
+import responses
+
+from ibm_cloud_sdk_core.authenticators import Authenticator, IAMAssumeAuthenticator
+from .utils.logger_utils import setup_test_logger
+
+setup_test_logger(logging.WARNING)
+
+
+def test_iam_assume_authenticator():
+    authenticator = IAMAssumeAuthenticator(apikey='my_apikey', iam_profile_crn='crn:iam-profile:123')
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM_ASSUME
+    assert authenticator.token_manager.url == 'https://iam.cloud.ibm.com'
+    assert authenticator.token_manager.disable_ssl_verification is False
+    assert authenticator.token_manager.headers is None
+    assert authenticator.token_manager.proxies is None
+    assert authenticator.token_manager.iam_delegate.apikey == 'my_apikey'
+    assert authenticator.token_manager.iam_profile_id is None
+    assert authenticator.token_manager.iam_profile_crn == 'crn:iam-profile:123'
+    assert authenticator.token_manager.iam_profile_name is None
+    assert authenticator.token_manager.iam_account_id is None
+
+    authenticator.set_iam_profile_id('my-id-123')
+    assert authenticator.token_manager.iam_profile_id == 'my-id-123'
+
+    authenticator.set_iam_profile_crn('crn:iam-profile:456')
+    assert authenticator.token_manager.iam_profile_crn == 'crn:iam-profile:456'
+
+    # We need to unset the other IAM related attributes to avoid validation error.
+    authenticator.set_iam_profile_id(None)
+    authenticator.set_iam_profile_crn(None)
+    authenticator.set_iam_profile_name_and_account_id('my-profile-name', 'my-acc-id')
+    assert authenticator.token_manager.iam_profile_name == 'my-profile-name'
+    assert authenticator.token_manager.iam_account_id == 'my-acc-id'
+
+    with pytest.raises(TypeError) as err:
+        authenticator.set_headers('dummy')
+    assert str(err.value) == 'headers must be a dictionary'
+
+    authenticator.set_headers({'dummy': 'headers'})
+    assert authenticator.token_manager.headers == {'dummy': 'headers'}
+
+    with pytest.raises(TypeError) as err:
+        authenticator.set_proxies('dummy')
+    assert str(err.value) == 'proxies must be a dictionary'
+
+    authenticator.set_proxies({'dummy': 'proxies'})
+    assert authenticator.token_manager.proxies == {'dummy': 'proxies'}
+
+    authenticator.set_disable_ssl_verification(True)
+    assert authenticator.token_manager.disable_ssl_verification
+
+
+def test_disable_ssl_verification():
+    authenticator = IAMAssumeAuthenticator(
+        apikey='my_apikey', iam_profile_id='my-profile-id', disable_ssl_verification=True
+    )
+    assert authenticator.token_manager.disable_ssl_verification is True
+
+    authenticator.set_disable_ssl_verification(False)
+    assert authenticator.token_manager.disable_ssl_verification is False
+
+
+def test_invalid_disable_ssl_verification_type():
+    with pytest.raises(TypeError) as err:
+        authenticator = IAMAssumeAuthenticator(
+            apikey='my_apikey', iam_profile_id='my-profile-id', disable_ssl_verification='True'
+        )
+    assert str(err.value) == 'disable_ssl_verification must be a bool'
+
+    authenticator = IAMAssumeAuthenticator(apikey='my_apikey', iam_profile_id='my-profile-id')
+    assert authenticator.token_manager.disable_ssl_verification is False
+
+    with pytest.raises(TypeError) as err:
+        authenticator.set_disable_ssl_verification('True')
+    assert str(err.value) == 'status must be a bool'
+
+
+def test_iam_assume_authenticator_validate_failed():
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator(None)
+    assert str(err.value) == 'The apikey shouldn\'t be None.'
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('{apikey}')
+    assert (
+        str(err.value) == 'The apikey shouldn\'t start or end with curly brackets or quotes. '
+        'Please remove any surrounding {, }, or \" characters.'
+    )
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator(
+            'my_apikey',
+            iam_profile_id='my_profile_id',
+            iam_profile_crn='my_profile_crn',
+            iam_profile_name='my_profile_name',
+            iam_account_id='my_account_id',
+        )
+    assert (
+        str(err.value) == 'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
+    )
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator(
+            'my_apikey',
+            iam_profile_id='my_profile_id',
+            iam_profile_crn='my_profile_crn',
+            iam_profile_name='my_profile_name',
+        )
+    assert (
+        str(err.value) == 'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
+    )
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('my_apikey', iam_profile_id='my_profile_id', iam_profile_crn='my_profile_crn')
+    assert (
+        str(err.value) == 'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
+    )
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('my_apikey', iam_profile_id='my_profile_id', iam_profile_name='my_profile_name')
+    assert (
+        str(err.value) == 'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
+    )
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('my_apikey', iam_profile_crn='my_profile_crn', iam_profile_name='my_profile_name')
+    assert (
+        str(err.value) == 'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
+    )
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('my_apikey', iam_profile_name='my_profile_name')
+    assert str(err.value) == '`iam_profile_name` and `iam_account_id` must be provided together, or not at all.'
+
+    with pytest.raises(ValueError) as err:
+        IAMAssumeAuthenticator('my_apikey', iam_account_id='my_account_id')
+    assert (
+        str(err.value) == 'Exactly one of `iam_profile_id`, `iam_profile_crn`, or `iam_profile_name` must be specified.'
+    )
+
+
+@responses.activate
+def test_get_token():
+    current_time = time.time()
+    url = "https://iam.cloud.ibm.com/identity/token"
+    access_token_layout = {
+        "username": "dummy",
+        "role": "Admin",
+        "permissions": ["administrator", "manage_catalog"],
+        "sub": "admin",
+        "iss": "sss",
+        "aud": "sss",
+        "uid": "sss",
+        "iat": current_time,
+        "exp": current_time + 3600,
+    }
+
+    access_token = jwt.encode(
+        access_token_layout, 'secret', algorithm='HS256', headers={'kid': '230498151c214b788dd97f22b85410a5'}
+    )
+    response = {
+        "access_token": access_token,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": current_time,
+        "refresh_token": "jy4gl91BQ",
+    }
+    responses.add(responses.POST, url=url, body=json.dumps(response), status=200)
+
+    auth_headers = {'Host': 'iam.cloud.ibm.com:443'}
+    authenticator = IAMAssumeAuthenticator('my_apikey', iam_profile_id='my_profile_id', headers=auth_headers)
+
+    # Simulate an SDK API request that needs to be authenticated.
+    request = {'headers': {}}
+
+    # Trigger the "get token" processing to obtain the access token and add to the "SDK request".
+    authenticator.authenticate(request)
+
+    # Verify that the "authenticate()" method added the Authorization header
+    assert request['headers']['Authorization'] is not None
+
+    # Verify that the "get token" call contained the Host header.
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.headers.get('Host') == 'iam.cloud.ibm.com:443'
+    assert 'profile_id=my_profile_id' in responses.calls[1].request.body
+
+
+def test_multiple_iam_assume_authenticators():
+    authenticator_1 = IAMAssumeAuthenticator('my_apikey', iam_profile_id='my_profile_id')
+    assert authenticator_1.token_manager.iam_delegate.request_payload['apikey'] == 'my_apikey'
+
+    authenticator_2 = IAMAssumeAuthenticator('my_other_apikey', iam_profile_id='my_profile_id_2')
+    assert authenticator_2.token_manager.iam_delegate.request_payload['apikey'] == 'my_other_apikey'
+    assert authenticator_1.token_manager.iam_delegate.request_payload['apikey'] == 'my_apikey'

--- a/test/test_iam_assume_token_manager.py
+++ b/test/test_iam_assume_token_manager.py
@@ -21,6 +21,7 @@ import time
 import urllib
 
 import jwt
+import pytest
 import responses
 
 from ibm_cloud_sdk_core import IAMAssumeTokenManager
@@ -213,3 +214,28 @@ def test_correct_properties_used_in_calls():
     # but those were not included in the second, assume type request.
     assert responses.calls[1].request.headers.get('Authorization') is None
     assert 'scope=my_scope' not in responses.calls[1].request.body
+
+
+@responses.activate
+def test_iam_assume_authenticator_unsupported_methods():
+    token_manager = IAMAssumeTokenManager('my_apikey', iam_profile_id='my_profile_id')
+
+    with pytest.raises(AttributeError) as err:
+        token_manager.set_scope('my_scope')
+    assert str(err.value) == "'IAMAssumeTokenManager' has no attribute 'set_scope'"
+
+    with pytest.raises(AttributeError) as err:
+        token_manager.set_client_id_and_secret('my_client_id', 'my_client_secret')
+    assert str(err.value) == "'IAMAssumeTokenManager' has no attribute 'set_client_id_and_secret'"
+
+    with pytest.raises(AttributeError) as err:
+        token_manager.set_headers({})
+    assert str(err.value) == "'IAMAssumeTokenManager' has no attribute 'set_headers'"
+
+    with pytest.raises(AttributeError) as err:
+        token_manager.set_proxies({})
+    assert str(err.value) == "'IAMAssumeTokenManager' has no attribute 'set_proxies'"
+
+    with pytest.raises(AttributeError) as err:
+        token_manager.set_disable_ssl_verification(True)
+    assert str(err.value) == "'IAMAssumeTokenManager' has no attribute 'set_disable_ssl_verification'"

--- a/test/test_iam_assume_token_manager.py
+++ b/test/test_iam_assume_token_manager.py
@@ -21,6 +21,7 @@ import time
 import urllib
 
 import jwt
+import pytest
 import responses
 
 from ibm_cloud_sdk_core import IAMAssumeTokenManager
@@ -190,3 +191,8 @@ def test_get_token():
 
     # The final result should be the other access token, which belong to the "assume" request.
     assert access_token == OTHER_ACCESS_TOKEN
+
+    # Make sure `refresh_token` is not accessible.
+    with pytest.raises(AttributeError) as err:
+        assert token_manager.refresh_token == "not_available"
+    assert str(err.value) == "'IAMAssumeTokenManager' has no attribute 'refresh_token'"

--- a/test/test_iam_assume_token_manager.py
+++ b/test/test_iam_assume_token_manager.py
@@ -1,0 +1,180 @@
+# coding: utf-8
+
+# Copyright 2019, 2024 IBM All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-docstring
+import json
+import logging
+import time
+
+import jwt
+import responses
+
+from ibm_cloud_sdk_core import IAMAssumeTokenManager
+from .utils.logger_utils import setup_test_logger
+
+
+MY_PROFILE_ID = 'my-profile-id'
+MY_PROFILE_CRN = 'my-profile-crn'
+MY_PROFILE_NAME = 'my-profile-name'
+MY_ACCOUNT_ID = 'my-account_id'
+
+
+setup_test_logger(logging.ERROR)
+
+
+def _get_current_time() -> int:
+    return int(time.time())
+
+
+ACCESS_TOKEN_LAYOUT = {
+    "username": "dummy",
+    "role": "Admin",
+    "permissions": ["administrator", "manage_catalog"],
+    "sub": "admin",
+    "iss": "sss",
+    "aud": "sss",
+    "uid": "sss",
+    "iat": _get_current_time(),
+    "exp": _get_current_time() + 3600,
+}
+
+ACCESS_TOKEN = jwt.encode(
+    ACCESS_TOKEN_LAYOUT, 'secret', algorithm='HS256', headers={'kid': '230498151c214b788dd97f22b85410a5'}
+)
+
+
+@responses.activate
+def test_request_token_with_profile_id():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = {
+        "access_token": ACCESS_TOKEN,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": _get_current_time() + 3600,
+        "refresh_token": "jy4gl91BQ",
+    }
+    responses.add(responses.POST, url=iam_url, body=json.dumps(response), status=200)
+
+    token_manager = IAMAssumeTokenManager("apikey", iam_profile_id=MY_PROFILE_ID)
+
+    # Make sure we don't have an access token yet.
+    assert token_manager.request_payload.get('access_token', None) is None
+
+    token_manager.request_token()
+
+    # Now the access token should be set along with the profile ID.
+    assert token_manager.request_payload.get('access_token') is not None
+    assert token_manager.request_payload.get('profile_id') == MY_PROFILE_ID
+    assert token_manager.request_payload.get('profile_crn') is None
+    assert token_manager.request_payload.get('profile_name') is None
+    assert token_manager.request_payload.get('account_id') is None
+
+
+@responses.activate
+def test_request_token_with_profile_crn():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = {
+        "access_token": ACCESS_TOKEN,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": _get_current_time() + 3600,
+        "refresh_token": "jy4gl91BQ",
+    }
+    responses.add(responses.POST, url=iam_url, body=json.dumps(response), status=200)
+
+    token_manager = IAMAssumeTokenManager("apikey", iam_profile_crn=MY_PROFILE_CRN)
+
+    # Make sure we don't have an access token yet.
+    assert token_manager.request_payload.get('access_token', None) is None
+
+    token_manager.request_token()
+
+    # Now the access token should be set along with the profile ID.
+    assert token_manager.request_payload.get('access_token') is not None
+    assert token_manager.request_payload.get('profile_id') is None
+    assert token_manager.request_payload.get('profile_crn') == MY_PROFILE_CRN
+    assert token_manager.request_payload.get('profile_name') is None
+    assert token_manager.request_payload.get('account_id') is None
+
+
+@responses.activate
+def test_request_token_with_profile_name_and_account_id():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = {
+        "access_token": ACCESS_TOKEN,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": _get_current_time() + 3600,
+        "refresh_token": "jy4gl91BQ",
+    }
+    responses.add(responses.POST, url=iam_url, body=json.dumps(response), status=200)
+
+    token_manager = IAMAssumeTokenManager("apikey", iam_profile_name=MY_PROFILE_NAME, iam_account_id=MY_ACCOUNT_ID)
+
+    # Make sure we don't have an access token yet.
+    assert token_manager.request_payload.get('access_token', None) is None
+
+    token_manager.request_token()
+
+    # Now the access token should be set along with the profile ID.
+    assert token_manager.request_payload.get('access_token') is not None
+    assert token_manager.request_payload.get('profile_id') is None
+    assert token_manager.request_payload.get('profile_crn') is None
+    assert token_manager.request_payload.get('profile_name') == MY_PROFILE_NAME
+    assert token_manager.request_payload.get('account') == MY_ACCOUNT_ID
+
+
+@responses.activate
+def test_request_token_uses_the_correct_grant_types():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = {
+        "access_token": ACCESS_TOKEN,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": _get_current_time() + 3600,
+        "refresh_token": "jy4gl91BQ",
+    }
+    response_json = json.dumps(response)
+    responses.add(responses.POST, url=iam_url, body=response_json, status=200)
+
+    token_manager = IAMAssumeTokenManager("apikey", iam_profile_id='my_profile_id')
+    token_manager.request_token()
+
+    assert token_manager.request_payload.get('grant_type') == 'urn:ibm:params:oauth:grant-type:assume'
+    assert token_manager.iam_delegate.request_payload.get('grant_type') == 'urn:ibm:params:oauth:grant-type:apikey'
+
+
+@responses.activate
+def test_request_token_uses_the_correct_headers():
+    iam_url = "https://iam.cloud.ibm.com/identity/token"
+    response = {
+        "access_token": ACCESS_TOKEN,
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "expiration": _get_current_time() + 3600,
+        "refresh_token": "jy4gl91BQ",
+    }
+    response_json = json.dumps(response)
+    responses.add(responses.POST, url=iam_url, body=response_json, status=200)
+
+    token_manager = IAMAssumeTokenManager("apikey", iam_profile_id='my_profile_id')
+    token_manager.request_token()
+
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.headers.get('User-Agent').startswith('ibm-python-sdk-core/iam-authenticator')
+    assert (
+        responses.calls[1].request.headers.get('User-Agent').startswith('ibm-python-sdk-core/iam-assume-authenticator')
+    )

--- a/test/test_iam_assume_token_manager.py
+++ b/test/test_iam_assume_token_manager.py
@@ -18,18 +18,14 @@
 import json
 import logging
 import time
+import urllib
 
 import jwt
 import responses
 
 from ibm_cloud_sdk_core import IAMAssumeTokenManager
+from ibm_cloud_sdk_core.api_exception import ApiException
 from .utils.logger_utils import setup_test_logger
-
-
-MY_PROFILE_ID = 'my-profile-id'
-MY_PROFILE_CRN = 'my-profile-crn'
-MY_PROFILE_NAME = 'my-profile-name'
-MY_ACCOUNT_ID = 'my-account_id'
 
 
 setup_test_logger(logging.ERROR)
@@ -39,6 +35,14 @@ def _get_current_time() -> int:
     return int(time.time())
 
 
+IAM_URL = "https://iam.cloud.ibm.com/identity/token"
+MY_PROFILE_ID = 'my-profile-id'
+MY_PROFILE_CRN = 'my-profile-crn'
+MY_PROFILE_NAME = 'my-profile-name'
+MY_ACCOUNT_ID = 'my-account_id'
+
+
+# The base layout of an access token.
 ACCESS_TOKEN_LAYOUT = {
     "username": "dummy",
     "role": "Admin",
@@ -50,33 +54,53 @@ ACCESS_TOKEN_LAYOUT = {
     "iat": _get_current_time(),
     "exp": _get_current_time() + 3600,
 }
-
+# Create two different access tokens by using different secrets for the encoding.
 ACCESS_TOKEN = jwt.encode(
     ACCESS_TOKEN_LAYOUT, 'secret', algorithm='HS256', headers={'kid': '230498151c214b788dd97f22b85410a5'}
 )
+OTHER_ACCESS_TOKEN = jwt.encode(
+    ACCESS_TOKEN_LAYOUT, 'other_secret', algorithm='HS256', headers={'kid': '230498151c214b788dd97f22b85410a5'}
+)
+# Create a base response and serialize it to a JSON string to avoid doing that in each test case.
+BASE_RESPONSE = {
+    "access_token": ACCESS_TOKEN,
+    "token_type": "Bearer",
+    "expires_in": 3600,
+    "expiration": _get_current_time() + 3600,
+    "refresh_token": "not_available",
+}
+BASE_RESPONSE_JSON = json.dumps(BASE_RESPONSE)
+# Create a second base response just like we did above, but use the other access token.
+OTHER_BASE_RESPONSE = BASE_RESPONSE.copy()
+OTHER_BASE_RESPONSE['access_token'] = OTHER_ACCESS_TOKEN
+OTHER_BASE_RESPONSE_JSON = json.dumps(OTHER_BASE_RESPONSE)
+
+
+def request_callback(request):
+    """Parse the form data, and return a response based on the `grant_type` value."""
+    form_data = urllib.parse.unquote(request.body)
+    params = dict(param.split('=') for param in form_data.split('&'))
+    if params.get('grant_type') == 'urn:ibm:params:oauth:grant-type:apikey':
+        return (200, {}, BASE_RESPONSE_JSON)
+    if params.get('grant_type') == 'urn:ibm:params:oauth:grant-type:assume':
+        return (200, {}, OTHER_BASE_RESPONSE_JSON)
+
+    raise ApiException(400)
 
 
 @responses.activate
 def test_request_token_with_profile_id():
-    iam_url = "https://iam.cloud.ibm.com/identity/token"
-    response = {
-        "access_token": ACCESS_TOKEN,
-        "token_type": "Bearer",
-        "expires_in": 3600,
-        "expiration": _get_current_time() + 3600,
-        "refresh_token": "jy4gl91BQ",
-    }
-    responses.add(responses.POST, url=iam_url, body=json.dumps(response), status=200)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_id=MY_PROFILE_ID)
 
     # Make sure we don't have an access token yet.
-    assert token_manager.request_payload.get('access_token', None) is None
+    assert token_manager.request_payload.get('access_token') is None
 
     token_manager.request_token()
 
     # Now the access token should be set along with the profile ID.
-    assert token_manager.request_payload.get('access_token') is not None
+    assert token_manager.request_payload.get('access_token') == ACCESS_TOKEN
     assert token_manager.request_payload.get('profile_id') == MY_PROFILE_ID
     assert token_manager.request_payload.get('profile_crn') is None
     assert token_manager.request_payload.get('profile_name') is None
@@ -85,25 +109,17 @@ def test_request_token_with_profile_id():
 
 @responses.activate
 def test_request_token_with_profile_crn():
-    iam_url = "https://iam.cloud.ibm.com/identity/token"
-    response = {
-        "access_token": ACCESS_TOKEN,
-        "token_type": "Bearer",
-        "expires_in": 3600,
-        "expiration": _get_current_time() + 3600,
-        "refresh_token": "jy4gl91BQ",
-    }
-    responses.add(responses.POST, url=iam_url, body=json.dumps(response), status=200)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_crn=MY_PROFILE_CRN)
 
     # Make sure we don't have an access token yet.
-    assert token_manager.request_payload.get('access_token', None) is None
+    assert token_manager.request_payload.get('access_token') is None
 
     token_manager.request_token()
 
     # Now the access token should be set along with the profile ID.
-    assert token_manager.request_payload.get('access_token') is not None
+    assert token_manager.request_payload.get('access_token') == ACCESS_TOKEN
     assert token_manager.request_payload.get('profile_id') is None
     assert token_manager.request_payload.get('profile_crn') == MY_PROFILE_CRN
     assert token_manager.request_payload.get('profile_name') is None
@@ -112,25 +128,17 @@ def test_request_token_with_profile_crn():
 
 @responses.activate
 def test_request_token_with_profile_name_and_account_id():
-    iam_url = "https://iam.cloud.ibm.com/identity/token"
-    response = {
-        "access_token": ACCESS_TOKEN,
-        "token_type": "Bearer",
-        "expires_in": 3600,
-        "expiration": _get_current_time() + 3600,
-        "refresh_token": "jy4gl91BQ",
-    }
-    responses.add(responses.POST, url=iam_url, body=json.dumps(response), status=200)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_name=MY_PROFILE_NAME, iam_account_id=MY_ACCOUNT_ID)
 
     # Make sure we don't have an access token yet.
-    assert token_manager.request_payload.get('access_token', None) is None
+    assert token_manager.request_payload.get('access_token') is None
 
     token_manager.request_token()
 
     # Now the access token should be set along with the profile ID.
-    assert token_manager.request_payload.get('access_token') is not None
+    assert token_manager.request_payload.get('access_token') == ACCESS_TOKEN
     assert token_manager.request_payload.get('profile_id') is None
     assert token_manager.request_payload.get('profile_crn') is None
     assert token_manager.request_payload.get('profile_name') == MY_PROFILE_NAME
@@ -140,15 +148,7 @@ def test_request_token_with_profile_name_and_account_id():
 @responses.activate
 def test_request_token_uses_the_correct_grant_types():
     iam_url = "https://iam.cloud.ibm.com/identity/token"
-    response = {
-        "access_token": ACCESS_TOKEN,
-        "token_type": "Bearer",
-        "expires_in": 3600,
-        "expiration": _get_current_time() + 3600,
-        "refresh_token": "jy4gl91BQ",
-    }
-    response_json = json.dumps(response)
-    responses.add(responses.POST, url=iam_url, body=response_json, status=200)
+    responses.add(responses.POST, url=iam_url, body=BASE_RESPONSE_JSON, status=200)
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_id='my_profile_id')
     token_manager.request_token()
@@ -159,16 +159,7 @@ def test_request_token_uses_the_correct_grant_types():
 
 @responses.activate
 def test_request_token_uses_the_correct_headers():
-    iam_url = "https://iam.cloud.ibm.com/identity/token"
-    response = {
-        "access_token": ACCESS_TOKEN,
-        "token_type": "Bearer",
-        "expires_in": 3600,
-        "expiration": _get_current_time() + 3600,
-        "refresh_token": "jy4gl91BQ",
-    }
-    response_json = json.dumps(response)
-    responses.add(responses.POST, url=iam_url, body=response_json, status=200)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_id='my_profile_id')
     token_manager.request_token()
@@ -178,3 +169,24 @@ def test_request_token_uses_the_correct_headers():
     assert (
         responses.calls[1].request.headers.get('User-Agent').startswith('ibm-python-sdk-core/iam-assume-authenticator')
     )
+
+
+@responses.activate
+def test_get_token():
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
+
+    token_manager = IAMAssumeTokenManager("apikey", iam_profile_id=MY_PROFILE_ID)
+
+    # Make sure we don't have an access token yet.
+    assert token_manager.request_payload.get('access_token') is None
+
+    access_token = token_manager.get_token()
+    # Now the access token should be set along with the profile ID.
+    assert token_manager.request_payload.get('access_token') == ACCESS_TOKEN
+    assert token_manager.request_payload.get('profile_id') == MY_PROFILE_ID
+    assert token_manager.request_payload.get('profile_crn') is None
+    assert token_manager.request_payload.get('profile_name') is None
+    assert token_manager.request_payload.get('account_id') is None
+
+    # The final result should be the other access token, which belong to the "assume" request.
+    assert access_token == OTHER_ACCESS_TOKEN

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,7 +29,7 @@ from ibm_cloud_sdk_core import convert_model, convert_list
 from ibm_cloud_sdk_core import get_query_param
 from ibm_cloud_sdk_core import read_external_sources
 from ibm_cloud_sdk_core.authenticators import Authenticator, BasicAuthenticator, IAMAuthenticator
-from ibm_cloud_sdk_core.utils import strip_extra_slashes, is_json_mimetype
+from ibm_cloud_sdk_core.utils import GzipStream, strip_extra_slashes, is_json_mimetype
 from .utils.logger_utils import setup_test_logger
 
 setup_test_logger(logging.ERROR)
@@ -659,3 +659,20 @@ def test_is_json_mimetype():
 
     assert is_json_mimetype('application/json') is True
     assert is_json_mimetype('application/json; charset=utf8') is True
+
+
+def test_gzip_stream_open_file():
+    cr_token_file = os.path.join(os.path.dirname(__file__), '../resources/cr-token.txt')
+    with open(cr_token_file, 'r', encoding='utf-8') as f:
+        stream = GzipStream(source=f)
+        assert stream is not None
+
+
+def test_gzip_stream_open_string():
+    stream = GzipStream(source='foobar')
+    assert stream is not None
+
+
+def test_gzip_stream_open_bytes():
+    stream = GzipStream(source=b'foobar')
+    assert stream is not None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -286,6 +286,17 @@ def test_get_authenticator_from_credential_file():
     assert authenticator.token_manager.scope is None
     del os.environ['IBM_CREDENTIALS_FILE']
 
+    file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-iam-assume.env')
+    os.environ['IBM_CREDENTIALS_FILE'] = file_path
+    authenticator = get_authenticator_from_environment('service 1')
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_IAM_ASSUME
+    assert authenticator.token_manager.iam_delegate.apikey == 'my-api-key'
+    assert authenticator.token_manager.iam_profile_id == 'iam-profile-1'
+    assert authenticator.token_manager.url == 'https://iam.cloud.ibm.com'
+    assert authenticator.token_manager.disable_ssl_verification is False
+    del os.environ['IBM_CREDENTIALS_FILE']
+
     file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-basic.env')
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('watson')

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -294,7 +294,10 @@ def test_get_authenticator_from_credential_file():
     assert authenticator.token_manager.iam_delegate.apikey == 'my-api-key'
     assert authenticator.token_manager.iam_profile_id == 'iam-profile-1'
     assert authenticator.token_manager.url == 'https://iam.cloud.ibm.com'
+    assert authenticator.token_manager.client_id is None
+    assert authenticator.token_manager.client_secret is None
     assert authenticator.token_manager.disable_ssl_verification is False
+    assert authenticator.token_manager.scope is None
     del os.environ['IBM_CREDENTIALS_FILE']
 
     file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-basic.env')

--- a/test_integration/test_iam_assume_authenticator_integration.py
+++ b/test_integration/test_iam_assume_authenticator_integration.py
@@ -1,0 +1,36 @@
+# pylint: disable=missing-docstring
+import os
+
+import logging
+
+from test.utils.logger_utils import setup_test_logger
+from ibm_cloud_sdk_core import get_authenticator_from_environment
+
+# Note: Only the unit tests are run by default.
+#
+# In order to test with a live IAM server, create file "iamassumetest.env" in the project root.
+# It should look like this:
+#
+# 	IAMASSUMETEST_AUTH_URL=<url>   e.g. https://iam.cloud.ibm.com
+# 	IAMASSUMETEST_AUTH_TYPE=iam
+# 	IAMASSUMETEST_APIKEY=<apikey>
+# 	IAMASSUMETEST_PROFILE_ID=<profile-id>
+#
+# Then run this command:
+# pytest test_integration/test_iam_assume_authenticator_integration.py
+
+# To enable debug logging as well as HTTP message logging,
+# change WARNING to DEBUG:
+setup_test_logger(logging.WARNING)
+
+
+def test_iam_authenticator():
+    os.environ['IBM_CREDENTIALS_FILE'] = 'iamassumetest.env'
+
+    authenticator = get_authenticator_from_environment('iamassumetest')
+    assert authenticator is not None
+
+    request = {'headers': {}}
+    authenticator.authenticate(request)
+    assert request['headers']['Authorization'] is not None
+    assert 'Bearer' in request['headers']['Authorization']


### PR DESCRIPTION
This commit introduces the new `IAMAssumeAuthenticator` which will fetch an IAM access token using the IAM `get_token` operation's "assume" grant type. The resulting access token allows the application to assume the identity of a trusted profile, similar to the "sudo" feature of Linux.