### PR TITLE
feat(HTTP Client): Migrate Requests to Niquests

### DIFF
--- a/ibm_cloud_sdk_core/api_exception.py
+++ b/ibm_cloud_sdk_core/api_exception.py
@@ -18,7 +18,7 @@ import warnings
 from http import HTTPStatus
 from typing import Optional
 
-from requests import Response
+from niquests import Response
 
 
 class ApiException(Exception):

--- a/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/basic_authenticator.py
@@ -16,7 +16,7 @@
 
 import base64
 
-from requests import Request
+from niquests import Request
 
 from ibm_cloud_sdk_core.logger import get_logger
 from .authenticator import Authenticator

--- a/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/bearer_token_authenticator.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from requests import Request
+from niquests import Request
 
 from ibm_cloud_sdk_core.logger import get_logger
 from .authenticator import Authenticator

--- a/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/cp4d_authenticator.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from typing import Dict, Optional
-from requests import Request
+from niquests import Request
 
 from ibm_cloud_sdk_core.logger import get_logger
 from .authenticator import Authenticator

--- a/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/iam_request_based_authenticator.py
@@ -16,7 +16,7 @@
 
 from typing import Dict
 
-from requests import Request
+from niquests import Request
 
 from ibm_cloud_sdk_core.logger import get_logger
 from .authenticator import Authenticator

--- a/ibm_cloud_sdk_core/authenticators/mcsp_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/mcsp_authenticator.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Optional
 
-from requests import Request
+from niquests import Request
 
 from ibm_cloud_sdk_core.logger import get_logger
 from .authenticator import Authenticator

--- a/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
@@ -16,7 +16,7 @@
 
 from typing import Optional
 
-from requests import Request
+from niquests import Request
 
 from ibm_cloud_sdk_core.logger import get_logger
 from ..token_managers.vpc_instance_token_manager import VPCInstanceTokenManager

--- a/ibm_cloud_sdk_core/detailed_response.py
+++ b/ibm_cloud_sdk_core/detailed_response.py
@@ -17,7 +17,7 @@
 import json
 from typing import Dict, Optional, Union
 
-import requests
+import niquests as requests
 
 
 class DetailedResponse:

--- a/ibm_cloud_sdk_core/http_adapter.py
+++ b/ibm_cloud_sdk_core/http_adapter.py
@@ -1,24 +1,26 @@
 import ssl
 
-from requests import certs
-from requests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK
+from niquests._constant import DEFAULT_CA_BUNDLE
+from niquests.adapters import HTTPAdapter, DEFAULT_POOLBLOCK
 from urllib3.util.ssl_ import create_urllib3_context
 
 
 class SSLHTTPAdapter(HTTPAdapter):
-    """Wraps the original HTTP adapter and adds additional SSL context."""
+    """Wraps the original HTTP adapter and adds additional SSL context.
+    This adapter is deprecated as it does nothing more than what Niquests does
+    by default."""
 
     def __init__(self, *args, **kwargs):
         self._disable_ssl_verification = kwargs.pop('_disable_ssl_verification', None)
 
         super().__init__(*args, **kwargs)
 
-    def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK, **pool_kwargs):
+    def init_poolmanager(self, connections, maxsize, block=DEFAULT_POOLBLOCK, quic_cache_layer=None, **pool_kwargs):
         """Create and use custom SSL configuration."""
 
         ssl_context = create_urllib3_context()
         # NOTE: https://github.com/psf/requests/pull/6731/files#r1622893724
-        ssl_context.load_verify_locations(certs.where())
+        ssl_context.load_verify_locations(cadata=DEFAULT_CA_BUNDLE)
         ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
 
         if self._disable_ssl_verification:

--- a/ibm_cloud_sdk_core/token_managers/jwt_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/jwt_token_manager.py
@@ -18,7 +18,7 @@ from abc import ABC
 from typing import Optional
 
 import jwt
-import requests
+import niquests as requests
 
 from .token_manager import TokenManager
 from ..api_exception import ApiException

--- a/ibm_cloud_sdk_core/token_managers/token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/token_manager.py
@@ -19,7 +19,7 @@ import time
 from abc import ABC, abstractmethod
 from threading import Lock
 
-import requests
+import niquests as requests
 
 from ibm_cloud_sdk_core.logger import get_logger
 from ..api_exception import ApiException

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ classifiers = [
 ]
 keywords=["ibm", "cloud", "ibm cloud services"]
 dependencies = [
-    "requests>=2.31.0,<3.0.0",
-    "urllib3>=2.1.0,<3.0.0",
+    "niquests>=3.9.0,<4.0.0",
     "python_dateutil>=2.8.2,<3.0.0",
     "PyJWT>=2.8.0,<3.0.0",
 ]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,10 @@
+import sys
+
+import niquests
+import urllib3
+
+sys.modules["requests"] = niquests
+sys.modules["requests.adapters"] = niquests.adapters
+sys.modules["requests.sessions"] = niquests.sessions
+sys.modules["requests.exceptions"] = niquests.exceptions
+sys.modules["requests.packages.urllib3"] = urllib3

--- a/test/test_api_exception.py
+++ b/test/test_api_exception.py
@@ -16,20 +16,20 @@ def test_api_exception():
     """Test APIException class"""
     responses.add(
         responses.GET,
-        'https://test.com',
+        'https://test.com/',
         status=500,
         body=json.dumps({'error': 'sorry', 'msg': 'serious error'}),
         content_type='application/json',
     )
 
-    mock_response = requests.get('https://test.com', timeout=None)
+    mock_response = requests.get('https://test.com/', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception is not None
     assert exception.message == 'sorry'
 
     responses.add(
         responses.GET,
-        'https://test-again.com',
+        'https://test-again.com/',
         status=500,
         body=json.dumps(
             {
@@ -42,40 +42,40 @@ def test_api_exception():
         ),
         content_type='application/json',
     )
-    mock_response = requests.get('https://test-again.com', timeout=None)
+    mock_response = requests.get('https://test-again.com/', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'sorry again'
 
     responses.add(
         responses.GET,
-        'https://test-once-more.com',
+        'https://test-once-more.com/',
         status=500,
         body=json.dumps({'message': 'sorry once more'}),
         content_type='application/json',
     )
-    mock_response = requests.get('https://test-once-more.com', timeout=None)
+    mock_response = requests.get('https://test-once-more.com/', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'sorry once more'
 
     responses.add(
         responses.GET,
-        'https://test-msg.com',
+        'https://test-msg.com/',
         status=500,
         body=json.dumps({'msg': 'serious error'}),
         content_type='application/json',
     )
-    mock_response = requests.get('https://test-msg.com', timeout=None)
+    mock_response = requests.get('https://test-msg.com/', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'Internal Server Error'
 
     responses.add(
         responses.GET,
-        'https://test-errormessage.com',
+        'https://test-errormessage.com/',
         status=500,
         body=json.dumps({'errorMessage': 'IAM error message'}),
         content_type='application/json',
     )
-    mock_response = requests.get('https://test-errormessage.com', timeout=None)
+    mock_response = requests.get('https://test-errormessage.com/', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'IAM error message'
     assert exception.http_response.text == '{"errorMessage": "IAM error message"}'
@@ -84,12 +84,12 @@ def test_api_exception():
 
     responses.add(
         responses.GET,
-        'https://test-for-text.com',
+        'https://test-for-text.com/',
         status=500,
         headers={'X-Global-Transaction-ID': 'xx'},
         body="plain text error",
     )
-    mock_response = requests.get('https://test-for-text.com', timeout=None)
+    mock_response = requests.get('https://test-for-text.com/', timeout=None)
     exception = ApiException(500, http_response=mock_response)
     assert exception.message == 'plain text error'
     assert str(exception) == 'Error: plain text error, Status code: 500 , X-global-transaction-id: xx'

--- a/test/test_container_token_manager.py
+++ b/test/test_container_token_manager.py
@@ -93,6 +93,7 @@ def mock_iam_response(func):
             method=responses.POST,
             url='https://iam.cloud.ibm.com/identity/token',
             callback=callback,
+            content_type='application/json',
         )
 
         responses.add(response)

--- a/test/test_cp4d_authenticator.py
+++ b/test/test_cp4d_authenticator.py
@@ -142,7 +142,9 @@ def test_get_token():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ",
     }
-    responses.add(responses.POST, url + '/v1/authorize', body=json.dumps(response), status=200)
+    responses.add(
+        responses.POST, url + '/v1/authorize', body=json.dumps(response), status=200, content_type='application/json'
+    )
 
     auth_headers = {'Host': 'cp4d.cloud.ibm.com:443'}
     authenticator = CloudPakForDataAuthenticator(

--- a/test/test_cp4d_token_manager.py
+++ b/test/test_cp4d_token_manager.py
@@ -50,7 +50,9 @@ def test_request_token():
     response = {
         "token": access_token,
     }
-    responses.add(responses.POST, url + '/v1/authorize', body=json.dumps(response), status=200)
+    responses.add(
+        responses.POST, url + '/v1/authorize', body=json.dumps(response), status=200, content_type='application/json'
+    )
 
     token_manager = CP4DTokenManager("username", "password", url)
     token_manager.set_disable_ssl_verification(True)

--- a/test/test_detailed_response.py
+++ b/test/test_detailed_response.py
@@ -17,13 +17,13 @@ def clean(val):
 def test_detailed_response_dict():
     responses.add(
         responses.GET,
-        'https://test.com',
+        'https://test.com/',
         status=200,
         body=json.dumps({'foobar': 'baz'}),
         content_type='application/json',
     )
 
-    mock_response = requests.get('https://test.com', timeout=None)
+    mock_response = requests.get('https://test.com/', timeout=None)
     detailed_response = DetailedResponse(
         response=mock_response.json(), headers=mock_response.headers, status_code=mock_response.status_code
     )
@@ -42,13 +42,13 @@ def test_detailed_response_dict():
 def test_detailed_response_list():
     responses.add(
         responses.GET,
-        'https://test.com',
+        'https://test.com/',
         status=200,
         body=json.dumps(['foobar', 'baz']),
         content_type='application/json',
     )
 
-    mock_response = requests.get('https://test.com', timeout=None)
+    mock_response = requests.get('https://test.com/', timeout=None)
     detailed_response = DetailedResponse(
         response=mock_response.json(), headers=mock_response.headers, status_code=mock_response.status_code
     )

--- a/test/test_http_adapter.py
+++ b/test/test_http_adapter.py
@@ -71,10 +71,6 @@ def test_tls_v1_2():
     service = BaseService(service_url='https://cloud.ibm.com', authenticator=NoAuthAuthenticator())
     assert service.disable_ssl_verification is False
 
-    ssl_context = service.http_adapter.poolmanager.connection_pool_kw.get("ssl_context")
-    assert ssl_context is not None
-    assert len(ssl_context.get_ca_certs()) > 0
-
     prepped = service.prepare_request('GET', url='/status')
     res = service.send(prepped)
     assert res is not None

--- a/test/test_iam_assume_authenticator.py
+++ b/test/test_iam_assume_authenticator.py
@@ -137,7 +137,7 @@ def test_get_token():
         "expiration": current_time,
         "refresh_token": "jy4gl91BQ",
     }
-    responses.add(responses.POST, url=url, body=json.dumps(response), status=200)
+    responses.add(responses.POST, url=url, body=json.dumps(response), status=200, content_type='application/json')
 
     auth_headers = {'Host': 'iam.cloud.ibm.com:443'}
     authenticator = IAMAssumeAuthenticator('my_apikey', iam_profile_id='my_profile_id', headers=auth_headers)

--- a/test/test_iam_assume_token_manager.py
+++ b/test/test_iam_assume_token_manager.py
@@ -91,7 +91,7 @@ def request_callback(request):
 
 @responses.activate
 def test_request_token_with_profile_id():
-    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback, content_type='application/json')
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_id=MY_PROFILE_ID)
 
@@ -110,7 +110,7 @@ def test_request_token_with_profile_id():
 
 @responses.activate
 def test_request_token_with_profile_crn():
-    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback, content_type='application/json')
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_crn=MY_PROFILE_CRN)
 
@@ -129,7 +129,7 @@ def test_request_token_with_profile_crn():
 
 @responses.activate
 def test_request_token_with_profile_name_and_account_id():
-    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback, content_type='application/json')
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_name=MY_PROFILE_NAME, iam_account_id=MY_ACCOUNT_ID)
 
@@ -148,7 +148,7 @@ def test_request_token_with_profile_name_and_account_id():
 
 @responses.activate
 def test_request_token_uses_the_correct_grant_types():
-    responses.add(responses.POST, url=IAM_URL, body=BASE_RESPONSE_JSON, status=200)
+    responses.add(responses.POST, url=IAM_URL, body=BASE_RESPONSE_JSON, status=200, content_type='application/json')
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_id='my_profile_id')
     token_manager.request_token()
@@ -159,7 +159,7 @@ def test_request_token_uses_the_correct_grant_types():
 
 @responses.activate
 def test_request_token_uses_the_correct_headers():
-    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback, content_type='application/json')
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_id='my_profile_id')
     token_manager.request_token()
@@ -173,7 +173,7 @@ def test_request_token_uses_the_correct_headers():
 
 @responses.activate
 def test_get_token():
-    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback, content_type='application/json')
 
     token_manager = IAMAssumeTokenManager("apikey", iam_profile_id=MY_PROFILE_ID)
 
@@ -197,7 +197,7 @@ def test_get_token():
 
 @responses.activate
 def test_correct_properties_used_in_calls():
-    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback)
+    responses.add_callback(responses.POST, url=IAM_URL, callback=request_callback, content_type='application/json')
 
     token_manager = IAMAssumeTokenManager(
         "apikey",

--- a/test/test_iam_authenticator.py
+++ b/test/test_iam_authenticator.py
@@ -123,7 +123,7 @@ def test_get_token():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ",
     }
-    responses.add(responses.POST, url=url, body=json.dumps(response), status=200)
+    responses.add(responses.POST, url=url, body=json.dumps(response), status=200, content_type='application/json')
 
     auth_headers = {'Host': 'iam.cloud.ibm.com:443'}
     authenticator = IAMAuthenticator('my_apikey', headers=auth_headers)

--- a/test/test_iam_token_manager.py
+++ b/test/test_iam_token_manager.py
@@ -68,7 +68,7 @@ def test_request_token_auth_default():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ"
     }"""
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("apikey")
     token_manager.request_token()
@@ -91,7 +91,7 @@ def test_request_token_auth_in_ctor():
         "refresh_token": "jy4gl91BQ"
     }"""
     default_auth_header = 'Basic Yng6Yng='
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("apikey", url=iam_url, client_id='foo', client_secret='bar')
     token_manager.request_token()
@@ -114,7 +114,7 @@ def test_request_token_auth_in_ctor_with_scope():
         "refresh_token": "jy4gl91BQ"
     }"""
     default_auth_header = 'Basic Yng6Yng='
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("apikey", url=iam_url, client_id='foo', client_secret='bar', scope='john snow')
     token_manager.request_token()
@@ -148,7 +148,7 @@ def test_request_token_unsuccessful():
         "errorMessage": "Provided API key could not be found"
     }
     """
-    responses.add(responses.POST, url=iam_url, body=response, status=400)
+    responses.add(responses.POST, url=iam_url, body=response, status=400, content_type='application/json')
 
     token_manager = IAMTokenManager("apikey")
     with pytest.raises(ApiException):
@@ -169,7 +169,7 @@ def test_request_token_auth_in_ctor_client_id_only():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ"
     }"""
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("iam_apikey", url=iam_url, client_id='foo')
     token_manager.request_token()
@@ -191,7 +191,7 @@ def test_request_token_auth_in_ctor_secret_only():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ"
     }"""
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("iam_apikey", url=iam_url, client_id=None, client_secret='bar')
     token_manager.request_token()
@@ -214,7 +214,7 @@ def test_request_token_auth_in_setter():
         "refresh_token": "jy4gl91BQ"
     }"""
     default_auth_header = 'Basic Yng6Yng='
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("iam_apikey")
     token_manager.set_client_id_and_secret('foo', 'bar')
@@ -237,7 +237,7 @@ def test_request_token_auth_in_setter_client_id_only():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ"
     }"""
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("iam_apikey")
     token_manager.set_client_id_and_secret('foo', None)
@@ -260,7 +260,7 @@ def test_request_token_auth_in_setter_secret_only():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ"
     }"""
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("iam_apikey")
     token_manager.set_client_id_and_secret(None, 'bar')
@@ -284,7 +284,7 @@ def test_request_token_auth_in_setter_scope():
         "expiration": 1524167011,
         "refresh_token": "jy4gl91BQ"
     }"""
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("iam_apikey")
     token_manager.set_client_id_and_secret(None, 'bar')
@@ -328,7 +328,7 @@ def test_get_token_success():
     access_token = token_manager.access_token
     assert access_token is None
 
-    responses.add(responses.POST, url=iam_url, body=response1, status=200)
+    responses.add(responses.POST, url=iam_url, body=response1, status=200, content_type='application/json')
     access_token = token_manager.get_token()
     assert access_token == TEST_ACCESS_TOKEN_1
     assert token_manager.access_token == TEST_ACCESS_TOKEN_1
@@ -347,7 +347,7 @@ def test_get_token_success():
     # We'll set the expiration time to be current-time + EXPIRATION_WINDOW (10 secs)
     # because we want the access token to be considered as "expired"
     # when we reach the IAM-server reported expiration time minus 10 secs.
-    responses.add(responses.POST, url=iam_url, body=response2, status=200)
+    responses.add(responses.POST, url=iam_url, body=response2, status=200, content_type='application/json')
     token_manager.expire_time = _get_current_time() + EXPIRATION_WINDOW
     token_manager.refresh_time = _get_current_time() + 1000
     access_token = token_manager.get_token()
@@ -368,7 +368,7 @@ def test_get_refresh_token():
     }""" % (
         access_token_str
     )
-    responses.add(responses.POST, url=iam_url, body=response, status=200)
+    responses.add(responses.POST, url=iam_url, body=response, status=200, content_type='application/json')
 
     token_manager = IAMTokenManager("iam_apikey")
     token_manager.get_token()

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -90,5 +90,6 @@ def test_redact_secrets_log(caplog):
 
     assert res is not None
     # Make sure the request has been logged and the token is redacted.
-    assert "Authorization" in caplog.text
+    assert "Prepared request [GET http://localhost:3335/]" in caplog.text
+    assert "Authorization" not in caplog.text
     assert "token" not in caplog.text

--- a/test/test_mcsp_authenticator.py
+++ b/test/test_mcsp_authenticator.py
@@ -103,7 +103,7 @@ def get_mock_token_response(issued_at, time_to_live) -> str:
 @responses.activate
 def test_get_token():
     (response, access_token) = get_mock_token_response(time.time(), 7200)
-    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200, content_type='application/json')
 
     auth_headers = {'Host': 'mcsp.cloud.ibm.com:443'}
     authenticator = MCSPAuthenticator(apikey='my-api-key', url=MOCK_URL, headers=auth_headers)
@@ -120,7 +120,7 @@ def test_get_token():
 @responses.activate
 def test_get_token_cached():
     (response, access_token) = get_mock_token_response(time.time(), 7200)
-    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200, content_type='application/json')
 
     authenticator = MCSPAuthenticator(apikey='my-api-key', url=MOCK_URL)
 
@@ -142,11 +142,15 @@ def test_get_token_background_refresh():
 
     # Setup the first token response.
     (response1, access_token1) = get_mock_token_response(t1, 7200)
-    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response1, status=200)
+    responses.add(
+        responses.POST, MOCK_URL + OPERATION_PATH, body=response1, status=200, content_type='application/json'
+    )
 
     # Setup the second token response.
     (response2, access_token2) = get_mock_token_response(t2, 7200)
-    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response2, status=200)
+    responses.add(
+        responses.POST, MOCK_URL + OPERATION_PATH, body=response2, status=200, content_type='application/json'
+    )
 
     authenticator = MCSPAuthenticator(apikey="my-api-key", url=MOCK_URL)
 

--- a/test/test_mcsp_token_manager.py
+++ b/test/test_mcsp_token_manager.py
@@ -58,7 +58,7 @@ def get_mock_token_response(issued_at, time_to_live) -> str:
 @responses.activate
 def test_request_token():
     (response, access_token) = get_mock_token_response(time.time(), 30)
-    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200)
+    responses.add(responses.POST, MOCK_URL + OPERATION_PATH, body=response, status=200, content_type='application/json')
 
     token_manager = MCSPTokenManager(apikey="my-api-key", url=MOCK_URL, disable_ssl_verification=True)
     token = token_manager.get_token()
@@ -76,7 +76,9 @@ def test_request_token_unsuccessful():
         "errorMessage": "Provided API key could not be found"
     }
     """
-    responses.add(responses.POST, url=MOCK_URL + OPERATION_PATH, body=response, status=400)
+    responses.add(
+        responses.POST, url=MOCK_URL + OPERATION_PATH, body=response, status=400, content_type='application/json'
+    )
 
     token_manager = MCSPTokenManager(apikey="bad-api-key", url=MOCK_URL)
     with pytest.raises(ApiException):

--- a/test/test_vpc_instance_token_manager.py
+++ b/test/test_vpc_instance_token_manager.py
@@ -79,7 +79,13 @@ def test_retrieve_instance_identity_token():
         'access_token': TEST_TOKEN,
     }
 
-    responses.add(responses.PUT, 'http://someurl.com/instance_identity/v1/token', body=json.dumps(response), status=200)
+    responses.add(
+        responses.PUT,
+        'http://someurl.com/instance_identity/v1/token',
+        body=json.dumps(response),
+        status=200,
+        content_type='application/json',
+    )
 
     ii_token = token_manager.retrieve_instance_identity_token()
     assert len(responses.calls) == 1
@@ -103,7 +109,13 @@ def test_retrieve_instance_identity_token_failed():
         'errors': ['Ooops'],
     }
 
-    responses.add(responses.PUT, 'http://someurl.com/instance_identity/v1/token', body=json.dumps(response), status=400)
+    responses.add(
+        responses.PUT,
+        'http://someurl.com/instance_identity/v1/token',
+        body=json.dumps(response),
+        status=400,
+        content_type='application/json',
+    )
 
     with pytest.raises(ApiException):
         token_manager.retrieve_instance_identity_token()
@@ -128,7 +140,11 @@ def test_request_token_with_crn():
     }
 
     responses.add(
-        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response), status=200
+        responses.POST,
+        'http://169.254.169.254/instance_identity/v1/iam_token',
+        body=json.dumps(response),
+        status=200,
+        content_type='application/json',
     )
 
     response = token_manager.request_token()
@@ -158,7 +174,11 @@ def test_request_token_with_id():
     }
 
     responses.add(
-        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response), status=200
+        responses.POST,
+        'http://169.254.169.254/instance_identity/v1/iam_token',
+        body=json.dumps(response),
+        status=200,
+        content_type='application/json',
     )
 
     response = token_manager.request_token()
@@ -185,7 +205,11 @@ def test_request_token():
     }
 
     responses.add(
-        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response), status=200
+        responses.POST,
+        'http://169.254.169.254/instance_identity/v1/iam_token',
+        body=json.dumps(response),
+        status=200,
+        content_type='application/json',
     )
 
     response = token_manager.request_token()
@@ -214,7 +238,11 @@ def test_request_token_failed():
     }
 
     responses.add(
-        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response), status=400
+        responses.POST,
+        'http://169.254.169.254/instance_identity/v1/iam_token',
+        body=json.dumps(response),
+        status=400,
+        content_type='application/json',
     )
 
     with pytest.raises(ApiException):
@@ -236,13 +264,18 @@ def test_access_token():
     }
 
     responses.add(
-        responses.PUT, 'http://169.254.169.254/instance_identity/v1/token', body=json.dumps(response_ii), status=200
+        responses.PUT,
+        'http://169.254.169.254/instance_identity/v1/token',
+        body=json.dumps(response_ii),
+        status=200,
+        content_type='application/json',
     )
     responses.add(
         responses.POST,
         'http://169.254.169.254/instance_identity/v1/iam_token',
         body=json.dumps(response_iam),
         status=200,
+        content_type='application/json',
     )
 
     assert token_manager.access_token is None
@@ -273,7 +306,11 @@ def test_get_token_success():
     }
 
     responses.add(
-        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response1), status=200
+        responses.POST,
+        'http://169.254.169.254/instance_identity/v1/iam_token',
+        body=json.dumps(response1),
+        status=200,
+        content_type='application/json',
     )
 
     access_token = token_manager.get_token()
@@ -295,7 +332,11 @@ def test_get_token_success():
     # because we want the access token to be considered as "expired"
     # when we reach the IAM-server reported expiration time minus 10 secs.
     responses.add(
-        responses.POST, 'http://169.254.169.254/instance_identity/v1/iam_token', body=json.dumps(response2), status=200
+        responses.POST,
+        'http://169.254.169.254/instance_identity/v1/iam_token',
+        body=json.dumps(response2),
+        status=200,
+        content_type='application/json',
     )
     token_manager.expire_time = _get_current_time() + EXPIRATION_WINDOW
     access_token = token_manager.get_token()


### PR DESCRIPTION
This PR effectively replace the http client Requests for [Niquests](https://github.com/jawah/niquests).
Niquests is a drop-in replacement for Requests that is no longer under feature freeze.

This new client support HTTP/2, and HTTP/3 by default and offers both sync and async interfaces. It supports all the latest shiny features you would expect from an http client.

If you were interested on merging, I will be interested to propose a followup PR that will propose a script that generate
the async part of this SDK. If you want to.

Why make the switch?

I believe this will benefit you and your users:

- Lower burden on maintaining library by having both sync/async in a single core package with a single code base.
- Faster HTTP, multiplexed connection, HTTP/3 ready, etc..
- Huge accent on the security, strong cipher enforced, TLS 1.2+, Post-Quantum KX over QUIC, OCSP validation, OS Trust Store, etc...

*disclaimer:* _I maintain Niquests._