### PR TITLE
feat(ContainerAuthenticator): enhance ContainerAuthenticator to support Code Engine workload

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -317,10 +317,10 @@ service = ExampleServiceV1.new_instance(service_name='example_service')
 ## Container Authentication
 The `ContainerAuthenticator` is intended to be used by application code
 running inside a compute resource managed by the IBM Kubernetes Service (IKS)
-in which a secure compute resource token (CR token) has been stored in a file
-within the compute resource's local file system.
+or IBM Cloud Code Engine in which a secure compute resource token (CR token)
+has been stored in a file within the compute resource's local file system.
 The CR token is similar to an IAM apikey except that it is managed automatically by
-the compute resource provider (IKS).
+the compute resource provider (IKS or Code Engine).
 This allows the application developer to:
 - avoid storing credentials in application code, configuration files or a password vault
 - avoid managing or rotating credentials
@@ -340,7 +340,9 @@ The IAM access token is added to each outbound request in the `Authorization` he
 
 - cr_token_filename: (optional) The name of the file containing the injected CR token value.
 If not specified, then the authenticator will first try `/var/run/secrets/tokens/vault-token`
-and then `/var/run/secrets/tokens/sa-token` as the default value (first file found is used).
+and then `/var/run/secrets/tokens/sa-token` and finally
+`/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token` as the default value
+(first file found is used).
 The application must have `read` permissions on the file containing the CR token value.
 
 - iam_profile_name: (optional) The name of the linked trusted IAM profile to be used when obtaining the

--- a/ibm_cloud_sdk_core/token_managers/container_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/container_token_manager.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-# Copyright 2021, 2024 IBM All Rights Reserved.
+# Copyright 2021, 2025 IBM All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,8 +53,9 @@ class ContainerTokenManager(IAMRequestBasedTokenManager):
         This can be used to obtain an access token with a specific scope.
 
     Keyword Args:
-        cr_token_filename: The name of the file containing the injected CR token value
-            (applies to IKS-managed compute resources). Defaults to "/var/run/secrets/tokens/vault-token".
+        cr_token_filename: The name of the file containing the injected CR token value. Defaults to
+            "/var/run/secrets/tokens/vault-token", or "/var/run/secrets/tokens/sa-token" and
+            "/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token" when not provided.
         iam_profile_name: The name of the linked trusted IAM profile to be used when obtaining the IAM access token
             (a CR token might map to multiple IAM profiles).
             One of iam_profile_name or iam_profile_id must be specified.
@@ -82,6 +83,7 @@ class ContainerTokenManager(IAMRequestBasedTokenManager):
 
     DEFAULT_CR_TOKEN_FILENAME1 = '/var/run/secrets/tokens/vault-token'
     DEFAULT_CR_TOKEN_FILENAME2 = '/var/run/secrets/tokens/sa-token'
+    DEFAULT_CR_TOKEN_FILENAME3 = '/var/run/secrets/codeengine.cloud.ibm.com/compute-resource-token/token'
 
     def __init__(
         self,
@@ -129,11 +131,14 @@ class ContainerTokenManager(IAMRequestBasedTokenManager):
                 # If the user specified a filename, then use that.
                 cr_token = self.read_file(self.cr_token_filename)
             else:
-                # If the user didn't specify a filename, then try our two defaults.
+                # If the user didn't specify a filename, then try our three defaults.
                 try:
                     cr_token = self.read_file(self.DEFAULT_CR_TOKEN_FILENAME1)
                 except:
-                    cr_token = self.read_file(self.DEFAULT_CR_TOKEN_FILENAME2)
+                    try:
+                        cr_token = self.read_file(self.DEFAULT_CR_TOKEN_FILENAME2)
+                    except:
+                        cr_token = self.read_file(self.DEFAULT_CR_TOKEN_FILENAME3)
             return cr_token
         except Exception as ex:
             # pylint: disable=broad-exception-raised


### PR DESCRIPTION
This pull request extends the existing ContainerAuthenticator to be aware of the hard-coded compute resource token path used by Code Engine. This allows a seamless usage of that authenticator and a move of workload between IKS/ROKS/Code Engine without changing a single line of code.

Documentation is adjusted to mention Code Engine in the context of the ContainerAuthenticator.