### PR TITLE
feat(auth): add support for new service version in VPC Instance Auth

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -473,11 +473,12 @@ authenticator = VPCInstanceAuthenticator(iam_profile_crn='crn:iam-profile-123')
 service = ExampleServiceV1(authenticator=authenticator)
 
 # 'service' can now be used to invoke operations.
+```
 
-# To use the new service version with custom token lifetime.
+To use the new service version with custom token lifetime:
+```python
 authenticator = VPCInstanceAuthenticator(
     iam_profile_id='iam-profile-id-123',
-    url='https://api.metadata.cloud.ibm.com',
     service_version='2025-08-26',
     token_lifetime=900  # 15 minutes
 )
@@ -488,12 +489,15 @@ External configuration:
 ```
 export EXAMPLE_SERVICE_AUTH_TYPE=vpc
 export EXAMPLE_SERVICE_IAM_PROFILE_CRN=crn:iam-profile-123
+```
 
 To use the new service version:
-export EXAMPLE_SERVICE_AUTH_TYPE=vpc
-export EXAMPLE_SERVICE_IAM_PROFILE_ID=iam-profile-id-123
-export EXAMPLE_SERVICE_SERVICE_VERSION=2025-08-26
 ```
+export EXAMPLE_SERVICE_AUTH_TYPE=vpc
+export EXAMPLE_SERVICE_IAM_PROFILE_CRN=crn:iam-profile-123
+export EXAMPLE_SERVICE_SERVICE_VPC_IMS_VERSION=2025-08-26
+```
+
 Application code:
 ```python
 from <sdk-package-name>.example_service_v1 import *

--- a/Authentication.md
+++ b/Authentication.md
@@ -440,7 +440,7 @@ The IAM access token is added to each outbound request in the `Authorization` he
 
 - iam_profile_id: (optional) the id of the linked trusted IAM profile to be used when obtaining the IAM access token.
 
-- url: (optional) The VPC Instance Metadata Service's base URL.
+- url: (optional) The VPC Instance Metadata Service's base URL.  
 The default value of this property is `http://169.254.169.254`. However, if the VPC Instance Metadata Service is configured
 with the HTTP Secure Protocol setting (`https`), then you should configure this property to be `https://api.metadata.cloud.ibm.com`.
 
@@ -467,17 +467,20 @@ from ibm_cloud_sdk_core.authenticators import VPCInstanceAuthenticator
 from <sdk-package-name>.example_service_v1 import *
 
 # Create the authenticator.
+authenticator = VPCInstanceAuthenticator(iam_profile_crn='crn:iam-profile-123')
+
+# Construct the service instance.
+service = ExampleServiceV1(authenticator=authenticator)
+
+# 'service' can now be used to invoke operations.
+
+# To use the new service version with custom token lifetime.
 authenticator = VPCInstanceAuthenticator(
     iam_profile_id='iam-profile-id-123',
     url='https://api.metadata.cloud.ibm.com',
     service_version='2025-08-26',
     token_lifetime=900  # 15 minutes
 )
-
-# Construct the service instance.
-service = ExampleServiceV1(authenticator=authenticator)
-
-# 'service' can now be used to invoke operations.
 ```
 
 ### Configuration example

--- a/Authentication.md
+++ b/Authentication.md
@@ -440,9 +440,16 @@ The IAM access token is added to each outbound request in the `Authorization` he
 
 - iam_profile_id: (optional) the id of the linked trusted IAM profile to be used when obtaining the IAM access token.
 
-- url: (optional) The VPC Instance Metadata Service's base URL.  
+- url: (optional) The VPC Instance Metadata Service's base URL.
 The default value of this property is `http://169.254.169.254`. However, if the VPC Instance Metadata Service is configured
 with the HTTP Secure Protocol setting (`https`), then you should configure this property to be `https://api.metadata.cloud.ibm.com`.
+
+- ServiceVersion: (optional) The VPC Instance Metadata Service version to use.
+The default value is `2022-03-01`. When set to `2025-08-26`, the authenticator will use the new API paths
+(`/identity/v1/token` and `/identity/v1/iam_tokens`) instead of the legacy paths.
+
+- TokenLifetime: (optional) The lifetime (in seconds) of the instance identity token.
+The default value is `300` seconds. This property can only be configured programmatically (not via environment variables).
 
 Usage Notes:
 1. At most one of `iam_profile_crn` or `iam_profile_id` may be specified. The specified value must map
@@ -460,7 +467,12 @@ from ibm_cloud_sdk_core.authenticators import VPCInstanceAuthenticator
 from <sdk-package-name>.example_service_v1 import *
 
 # Create the authenticator.
-authenticator = VPCInstanceAuthenticator(iam_profile_crn='crn:iam-profile-123')
+authenticator = VPCInstanceAuthenticator(
+    iam_profile_id='iam-profile-id-123',
+    url='https://api.metadata.cloud.ibm.com',
+    service_version='2025-08-26',
+    token_lifetime=900  # 15 minutes
+)
 
 # Construct the service instance.
 service = ExampleServiceV1(authenticator=authenticator)
@@ -473,6 +485,11 @@ External configuration:
 ```
 export EXAMPLE_SERVICE_AUTH_TYPE=vpc
 export EXAMPLE_SERVICE_IAM_PROFILE_CRN=crn:iam-profile-123
+
+To use the new service version:
+export EXAMPLE_SERVICE_AUTH_TYPE=vpc
+export EXAMPLE_SERVICE_IAM_PROFILE_ID=iam-profile-id-123
+export EXAMPLE_SERVICE_SERVICE_VERSION=2025-08-26
 ```
 Application code:
 ```python

--- a/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
@@ -55,6 +55,7 @@ class VPCInstanceAuthenticator(Authenticator):
     """
 
     DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254'
+    VPC_AUTH_METADATA_SERVICE_SUPPORTED_VERSIONS = ('2022-03-01', '2025-08-26')
 
     def __init__(
         self,
@@ -93,6 +94,12 @@ class VPCInstanceAuthenticator(Authenticator):
 
         if self.token_manager.iam_profile_crn and self.token_manager.iam_profile_id:
             raise ValueError('At most one of "iam_profile_id" or "iam_profile_crn" may be specified.')
+
+        if self.token_manager.service_version not in self.VPC_AUTH_METADATA_SERVICE_SUPPORTED_VERSIONS:
+            raise ValueError(
+                f"Invalid service version '{self.token_manager.service_version}'. "
+                f"Supported versions are: {', '.join(self.VPC_AUTH_METADATA_SERVICE_SUPPORTED_VERSIONS)}"
+            )
 
     def authenticate(self, req: Request) -> None:
         """Adds IAM authentication information to the request.
@@ -155,3 +162,4 @@ class VPCInstanceAuthenticator(Authenticator):
             service_version (str): the version of the service.
         """
         self.token_manager.set_service_version(service_version)
+        self.validate()

--- a/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
@@ -57,13 +57,21 @@ class VPCInstanceAuthenticator(Authenticator):
     DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254'
 
     def __init__(
-        self, iam_profile_crn: Optional[str] = None, iam_profile_id: Optional[str] = None, url: Optional[str] = None
+        self, iam_profile_crn: Optional[str] = None, iam_profile_id: Optional[str] = None, url: Optional[str] = None,
+        token_lifetime: Optional[int] = None, service_version: Optional[str] = None,
     ) -> None:
         if not url:
             url = self.DEFAULT_IMS_ENDPOINT
 
+        if not token_lifetime:
+            token_lifetime = VPCInstanceTokenManager.DEFAULT_TOKEN_LIFETIME
+
+        if not service_version:
+            service_version = VPCInstanceTokenManager.DEFAULT_SERVICE_VERSION
+
         self.token_manager = VPCInstanceTokenManager(
-            url=url, iam_profile_crn=iam_profile_crn, iam_profile_id=iam_profile_id
+            url=url, iam_profile_crn=iam_profile_crn, iam_profile_id=iam_profile_id, token_lifetime=token_lifetime,
+            service_version=service_version,
         )
 
         self.validate()
@@ -123,3 +131,20 @@ class VPCInstanceAuthenticator(Authenticator):
         """
         self.token_manager.set_iam_profile_id(iam_profile_id)
         self.validate()
+
+    def set_token_lifetime(self, token_lifetime: int) -> None:
+        """Sets the token lifetime.
+
+        Args:
+            token_lifetime (int): the integer value of the token lifetime.
+        """
+        self.token_manager.set_token_lifetime(token_lifetime)
+
+
+    def set_service_version(self, service_version: str) -> None:
+        """Sets the service version.
+
+        Args:
+            service_version (str): the version of the service.
+        """
+        self.token_manager.set_service_version(service_version)

--- a/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
@@ -73,7 +73,7 @@ class VPCInstanceAuthenticator(Authenticator):
             token_lifetime = VPCInstanceTokenManager.DEFAULT_TOKEN_LIFETIME
 
         if not service_version:
-            service_version = VPCInstanceTokenManager.DEFAULT_SERVICE_VERSION
+            service_version = VPCInstanceTokenManager.METADATA_SERVICE_VERSION
 
         self.token_manager = VPCInstanceTokenManager(
             url=url,

--- a/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
+++ b/ibm_cloud_sdk_core/authenticators/vpc_instance_authenticator.py
@@ -57,8 +57,13 @@ class VPCInstanceAuthenticator(Authenticator):
     DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254'
 
     def __init__(
-        self, iam_profile_crn: Optional[str] = None, iam_profile_id: Optional[str] = None, url: Optional[str] = None,
-        token_lifetime: Optional[int] = None, service_version: Optional[str] = None,
+        self,
+        iam_profile_crn: Optional[str] = None,
+        iam_profile_id: Optional[str] = None,
+        url: Optional[str] = None,
+        *,
+        token_lifetime: Optional[int] = None,
+        service_version: Optional[str] = None,
     ) -> None:
         if not url:
             url = self.DEFAULT_IMS_ENDPOINT
@@ -70,7 +75,10 @@ class VPCInstanceAuthenticator(Authenticator):
             service_version = VPCInstanceTokenManager.DEFAULT_SERVICE_VERSION
 
         self.token_manager = VPCInstanceTokenManager(
-            url=url, iam_profile_crn=iam_profile_crn, iam_profile_id=iam_profile_id, token_lifetime=token_lifetime,
+            url=url,
+            iam_profile_crn=iam_profile_crn,
+            iam_profile_id=iam_profile_id,
+            token_lifetime=token_lifetime,
             service_version=service_version,
         )
 
@@ -139,7 +147,6 @@ class VPCInstanceAuthenticator(Authenticator):
             token_lifetime (int): the integer value of the token lifetime.
         """
         self.token_manager.set_token_lifetime(token_lifetime)
-
 
     def set_service_version(self, service_version: str) -> None:
         """Sets the service version.

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -127,6 +127,7 @@ def __construct_authenticator(config: dict) -> Authenticator:
             iam_profile_crn=config.get('IAM_PROFILE_CRN'),
             iam_profile_id=config.get('IAM_PROFILE_ID'),
             url=config.get('AUTH_URL'),
+            service_version=config.get('SERVICE_VERSION'),
         )
     elif auth_type == Authenticator.AUTHTYPE_MCSP.lower():
         authenticator = MCSPAuthenticator(

--- a/ibm_cloud_sdk_core/get_authenticator.py
+++ b/ibm_cloud_sdk_core/get_authenticator.py
@@ -127,7 +127,7 @@ def __construct_authenticator(config: dict) -> Authenticator:
             iam_profile_crn=config.get('IAM_PROFILE_CRN'),
             iam_profile_id=config.get('IAM_PROFILE_ID'),
             url=config.get('AUTH_URL'),
-            service_version=config.get('SERVICE_VERSION'),
+            service_version=config.get('VPC_IMS_VERSION'),
         )
     elif auth_type == Authenticator.AUTHTYPE_MCSP.lower():
         authenticator = MCSPAuthenticator(

--- a/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
@@ -59,8 +59,13 @@ class VPCInstanceTokenManager(JWTTokenManager):
     DEFAULT_TOKEN_LIFETIME = 300
 
     def __init__(
-        self, iam_profile_crn: Optional[str] = None, iam_profile_id: Optional[str] = None, url: Optional[str] = None,
-        token_lifetime: Optional[int] = None, service_version: Optional[str] = None,
+        self,
+        iam_profile_crn: Optional[str] = None,
+        iam_profile_id: Optional[str] = None,
+        url: Optional[str] = None,
+        *,
+        token_lifetime: Optional[int] = None,
+        service_version: Optional[str] = None,
     ) -> None:
         if not url:
             url = self.DEFAULT_IMS_ENDPOINT

--- a/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
@@ -57,6 +57,11 @@ class VPCInstanceTokenManager(JWTTokenManager):
     TOKEN_NAME = 'access_token'
     IAM_EXPIRATION_WINDOW = 10
     DEFAULT_TOKEN_LIFETIME = 300
+    VPC_AUTH_METADATA_FLAVOR = 'ibm'
+    VPC_AUTH_OPERATION_PATCH_CREATE_ACCESS_TOKEN = '/instance_identity/v1/token'
+    VPC_AUTH_OPERATION_PATCH_CREATE_ACCESS_TOKEN_V2 = '/identity/v1/token'
+    VPC_AUTH_OPERATION_PATCH_CREATE_IAM_TOKEN = '/instance_identity/v1/iam_token'
+    VPC_AUTH_OPERATION_PATCH_CREATE_IAM_TOKEN_V2 = "/identity/v1/iam_tokens"
 
     def __init__(
         self,
@@ -97,9 +102,9 @@ class VPCInstanceTokenManager(JWTTokenManager):
         instance_identity_token = self.retrieve_instance_identity_token()
 
         if self.service_version == "2025-08-26":
-            url = self.url + '/identity/v1/iam_tokens'
+            url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_IAM_TOKEN_V2
         else:
-            url = self.url + '/instance_identity/v1/iam_token'
+            url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_IAM_TOKEN
 
         request_payload = None
         if self.iam_profile_crn:
@@ -110,6 +115,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
         headers = {
             'Content-Type': 'application/json',
             'Accept': 'application/json',
+            'Metadata-Flavor': self.VPC_AUTH_METADATA_FLAVOR,
             'Authorization': 'Bearer ' + instance_identity_token,
             'User-Agent': self._get_user_agent(),
         }
@@ -169,14 +175,14 @@ class VPCInstanceTokenManager(JWTTokenManager):
         """
 
         if self.service_version == "2025-08-26":
-            url = self.url + '/identity/v1/token'
+            url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_ACCESS_TOKEN_V2
         else:
-            url = self.url + '/instance_identity/v1/token'
+            url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_ACCESS_TOKEN
 
         headers = {
             'Content-type': 'application/json',
             'Accept': 'application/json',
-            'Metadata-Flavor': 'ibm',
+            'Metadata-Flavor': self.VPC_AUTH_METADATA_FLAVOR,
             'User-Agent': self._get_user_agent(),
         }
 

--- a/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
@@ -52,22 +52,32 @@ class VPCInstanceTokenManager(JWTTokenManager):
         url (str, optional): The VPC Instance Metadata Service's base endpoint URL.
     """
 
-    METADATA_SERVICE_VERSION = '2022-03-01'
+    DEFAULT_SERVICE_VERSION = '2022-03-01'
     DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254'
     TOKEN_NAME = 'access_token'
     IAM_EXPIRATION_WINDOW = 10
+    DEFAULT_TOKEN_LIFETIME = 300
 
     def __init__(
-        self, iam_profile_crn: Optional[str] = None, iam_profile_id: Optional[str] = None, url: Optional[str] = None
+        self, iam_profile_crn: Optional[str] = None, iam_profile_id: Optional[str] = None, url: Optional[str] = None,
+        token_lifetime: Optional[int] = None, service_version: Optional[str] = None,
     ) -> None:
         if not url:
             url = self.DEFAULT_IMS_ENDPOINT
+
+        if not token_lifetime:
+            token_lifetime = self.DEFAULT_TOKEN_LIFETIME
+
+        if not service_version:
+            service_version = self.DEFAULT_SERVICE_VERSION
 
         super().__init__(url, token_name=self.TOKEN_NAME)
         self._set_user_agent(_build_user_agent('vpc-instance-authenticator'))
 
         self.iam_profile_crn = iam_profile_crn
         self.iam_profile_id = iam_profile_id
+        self.token_lifetime = token_lifetime
+        self.service_version = service_version
 
     def request_token(self) -> dict:
         """RequestToken will use the VPC Instance Metadata Service to
@@ -81,7 +91,10 @@ class VPCInstanceTokenManager(JWTTokenManager):
         # Retrieve the Instance Identity Token first.
         instance_identity_token = self.retrieve_instance_identity_token()
 
-        url = self.url + '/instance_identity/v1/iam_token'
+        if self.service_version == "2025-08-26":
+            url = self.url + '/identity/v1/iam_tokens'
+        else:
+            url = self.url + '/instance_identity/v1/iam_token'
 
         request_payload = None
         if self.iam_profile_crn:
@@ -101,7 +114,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             method='POST',
             url=url,
             headers=headers,
-            params={'version': self.METADATA_SERVICE_VERSION},
+            params={'version': self.service_version},
             data=json.dumps(request_payload) if request_payload else None,
         )
         logger.debug('Returned from VPC \'create_iam_token\' operation.')
@@ -126,6 +139,22 @@ class VPCInstanceTokenManager(JWTTokenManager):
         """
         self.iam_profile_id = iam_profile_id
 
+    def set_token_lifetime(self, token_lifetime: int) -> None:
+        """Sets the lifetime of token.
+
+        Args:
+            token_lifetime (int): the integer value of the token lifetime.
+        """
+        self.token_lifetime = token_lifetime
+
+    def set_service_version(self, service_version: str) -> None:
+        """Sets the service version.
+
+        Args:
+            service_version (str): The version of the VPC Instance Metadata Service API.
+        """
+        self.service_version = service_version
+
     def retrieve_instance_identity_token(self) -> str:
         """Retrieves the local compute resource's instance identity token using
            the "create_access_token" operation of the local VPC Instance Metadata Service API.
@@ -134,7 +163,10 @@ class VPCInstanceTokenManager(JWTTokenManager):
             The retrieved instance identity token string.
         """
 
-        url = self.url + '/instance_identity/v1/token'
+        if self.service_version == "2025-08-26":
+            url = self.url + '/identity/v1/token'
+        else:
+            url = self.url + '/instance_identity/v1/token'
 
         headers = {
             'Content-type': 'application/json',
@@ -143,14 +175,14 @@ class VPCInstanceTokenManager(JWTTokenManager):
             'User-Agent': self._get_user_agent(),
         }
 
-        request_body = {'expires_in': 300}
+        request_body = {'expires_in': self.token_lifetime}
 
         logger.debug('Invoking VPC \'create_access_token\' operation: %s', url)
         response = self._request(
             method='PUT',
             url=url,
             headers=headers,
-            params={'version': self.METADATA_SERVICE_VERSION},
+            params={'version': self.service_version},
             data=json.dumps(request_body),
         )
         logger.debug('Returned from VPC \'create_access_token\' operation.')

--- a/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
+++ b/ibm_cloud_sdk_core/token_managers/vpc_instance_token_manager.py
@@ -52,7 +52,8 @@ class VPCInstanceTokenManager(JWTTokenManager):
         url (str, optional): The VPC Instance Metadata Service's base endpoint URL.
     """
 
-    DEFAULT_SERVICE_VERSION = '2022-03-01'
+    METADATA_SERVICE_VERSION = '2022-03-01'
+    METADATA_SERVICE_VERSION_V2 = '2025-08-26'
     DEFAULT_IMS_ENDPOINT = 'http://169.254.169.254'
     TOKEN_NAME = 'access_token'
     IAM_EXPIRATION_WINDOW = 10
@@ -79,7 +80,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             token_lifetime = self.DEFAULT_TOKEN_LIFETIME
 
         if not service_version:
-            service_version = self.DEFAULT_SERVICE_VERSION
+            service_version = self.METADATA_SERVICE_VERSION
 
         super().__init__(url, token_name=self.TOKEN_NAME)
         self._set_user_agent(_build_user_agent('vpc-instance-authenticator'))
@@ -101,7 +102,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
         # Retrieve the Instance Identity Token first.
         instance_identity_token = self.retrieve_instance_identity_token()
 
-        if self.service_version == "2025-08-26":
+        if self.service_version == self.METADATA_SERVICE_VERSION_V2:
             url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_IAM_TOKEN_V2
         else:
             url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_IAM_TOKEN
@@ -174,7 +175,7 @@ class VPCInstanceTokenManager(JWTTokenManager):
             The retrieved instance identity token string.
         """
 
-        if self.service_version == "2025-08-26":
+        if self.service_version == self.METADATA_SERVICE_VERSION_V2:
             url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_ACCESS_TOKEN_V2
         else:
             url = self.url + self.VPC_AUTH_OPERATION_PATCH_CREATE_ACCESS_TOKEN

--- a/test/test_get_authenticator.py
+++ b/test/test_get_authenticator.py
@@ -159,6 +159,34 @@ def test_get_authenticator_from_credential_file():
     assert authenticator.token_manager.url == 'http://169.254.169.254'
     del os.environ['IBM_CREDENTIALS_FILE']
 
+
+def test_vpc_authenticator_from_environment_with_service_version():
+    os.environ['VPC_TEST_AUTH_TYPE'] = 'vpc'
+    os.environ['VPC_TEST_IAM_PROFILE_CRN'] = 'crn:iam-profile:456'
+    os.environ['VPC_TEST_SERVICE_VERSION'] = '2025-08-26'
+
+    authenticator = get_authenticator_from_environment('vpc_test')
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_VPC
+    assert authenticator.token_manager.iam_profile_crn == 'crn:iam-profile:456'
+    assert authenticator.token_manager.service_version == '2025-08-26'
+
+    del os.environ['VPC_TEST_AUTH_TYPE']
+    del os.environ['VPC_TEST_IAM_PROFILE_CRN']
+    del os.environ['VPC_TEST_SERVICE_VERSION']
+
+
+def test_vpc_authenticator_from_environment_defaults():
+    os.environ['VPC_DEFAULT_AUTH_TYPE'] = 'vpc'
+
+    authenticator = get_authenticator_from_environment('vpc_default')
+    assert authenticator is not None
+    assert authenticator.authentication_type() == Authenticator.AUTHTYPE_VPC
+    assert authenticator.token_manager.service_version == '2022-03-01'
+    assert authenticator.token_manager.token_lifetime == 300
+
+    del os.environ['VPC_DEFAULT_AUTH_TYPE']
+
     file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-mcsp.env')
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('service1')

--- a/test/test_get_authenticator.py
+++ b/test/test_get_authenticator.py
@@ -163,7 +163,7 @@ def test_get_authenticator_from_credential_file():
 def test_vpc_authenticator_from_environment_with_service_version():
     os.environ['VPC_TEST_AUTH_TYPE'] = 'vpc'
     os.environ['VPC_TEST_IAM_PROFILE_CRN'] = 'crn:iam-profile:456'
-    os.environ['VPC_TEST_SERVICE_VERSION'] = '2025-08-26'
+    os.environ['VPC_TEST_VPC_IMS_VERSION'] = '2025-08-26'
 
     authenticator = get_authenticator_from_environment('vpc_test')
     assert authenticator is not None
@@ -173,7 +173,7 @@ def test_vpc_authenticator_from_environment_with_service_version():
 
     del os.environ['VPC_TEST_AUTH_TYPE']
     del os.environ['VPC_TEST_IAM_PROFILE_CRN']
-    del os.environ['VPC_TEST_SERVICE_VERSION']
+    del os.environ['VPC_TEST_VPC_IMS_VERSION']
 
 
 def test_vpc_authenticator_from_environment_defaults():
@@ -192,7 +192,7 @@ def test_vpc_authenticator_from_environment_unsupported_version():
     """Test that unsupported service version raises ValueError."""
     os.environ['VPC_INVALID_AUTH_TYPE'] = 'vpc'
     os.environ['VPC_INVALID_IAM_PROFILE_ID'] = 'iam-id-123'
-    os.environ['VPC_INVALID_SERVICE_VERSION'] = '2023-12-31'
+    os.environ['VPC_INVALID_VPC_IMS_VERSION'] = '2023-12-31'
 
     with pytest.raises(ValueError) as err:
         get_authenticator_from_environment('vpc_invalid')
@@ -202,7 +202,7 @@ def test_vpc_authenticator_from_environment_unsupported_version():
 
     del os.environ['VPC_INVALID_AUTH_TYPE']
     del os.environ['VPC_INVALID_IAM_PROFILE_ID']
-    del os.environ['VPC_INVALID_SERVICE_VERSION']
+    del os.environ['VPC_INVALID_VPC_IMS_VERSION']
 
     file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-mcsp.env')
     os.environ['IBM_CREDENTIALS_FILE'] = file_path

--- a/test/test_get_authenticator.py
+++ b/test/test_get_authenticator.py
@@ -187,6 +187,23 @@ def test_vpc_authenticator_from_environment_defaults():
 
     del os.environ['VPC_DEFAULT_AUTH_TYPE']
 
+
+def test_vpc_authenticator_from_environment_unsupported_version():
+    """Test that unsupported service version raises ValueError."""
+    os.environ['VPC_INVALID_AUTH_TYPE'] = 'vpc'
+    os.environ['VPC_INVALID_IAM_PROFILE_ID'] = 'iam-id-123'
+    os.environ['VPC_INVALID_SERVICE_VERSION'] = '2023-12-31'
+
+    with pytest.raises(ValueError) as err:
+        get_authenticator_from_environment('vpc_invalid')
+
+    assert 'Invalid service version' in str(err.value)
+    assert '2022-03-01, 2025-08-26' in str(err.value)
+
+    del os.environ['VPC_INVALID_AUTH_TYPE']
+    del os.environ['VPC_INVALID_IAM_PROFILE_ID']
+    del os.environ['VPC_INVALID_SERVICE_VERSION']
+
     file_path = os.path.join(os.path.dirname(__file__), '../resources/ibm-credentials-mcsp.env')
     os.environ['IBM_CREDENTIALS_FILE'] = file_path
     authenticator = get_authenticator_from_environment('service1')

--- a/test/test_vpc_instance_authenticator.py
+++ b/test/test_vpc_instance_authenticator.py
@@ -66,3 +66,46 @@ def test_authenticate():
 
     # Verify that the "authenticate()" method added the Authorization header
     assert request['headers']['Authorization'] == 'Bearer mock_token'
+
+
+def test_constructor_with_token_lifetime():
+    authenticator = VPCInstanceAuthenticator(
+        iam_profile_id=TEST_IAM_PROFILE_ID,
+        url='someurl.com',
+        token_lifetime=600
+    )
+    assert authenticator is not None
+    assert authenticator.token_manager.token_lifetime == 600
+
+
+def test_constructor_with_service_version():
+    authenticator = VPCInstanceAuthenticator(
+        iam_profile_id=TEST_IAM_PROFILE_ID,
+        url='someurl.com',
+        service_version='2025-08-26'
+    )
+    assert authenticator is not None
+    assert authenticator.token_manager.service_version == '2025-08-26'
+
+
+def test_constructor_with_defaults():
+    authenticator = VPCInstanceAuthenticator(iam_profile_id=TEST_IAM_PROFILE_ID)
+    assert authenticator is not None
+    assert authenticator.token_manager.token_lifetime == 300  # DEFAULT_TOKEN_LIFETIME
+    assert authenticator.token_manager.service_version == '2022-03-01'  # DEFAULT_SERVICE_VERSION
+
+
+def test_set_token_lifetime():
+    authenticator = VPCInstanceAuthenticator(iam_profile_id=TEST_IAM_PROFILE_ID)
+    assert authenticator.token_manager.token_lifetime == 300
+
+    authenticator.set_token_lifetime(900)
+    assert authenticator.token_manager.token_lifetime == 900
+
+
+def test_set_service_version():
+    authenticator = VPCInstanceAuthenticator(iam_profile_id=TEST_IAM_PROFILE_ID)
+    assert authenticator.token_manager.service_version == '2022-03-01'
+
+    authenticator.set_service_version('2025-08-26')
+    assert authenticator.token_manager.service_version == '2025-08-26'

--- a/test/test_vpc_instance_authenticator.py
+++ b/test/test_vpc_instance_authenticator.py
@@ -69,20 +69,14 @@ def test_authenticate():
 
 
 def test_constructor_with_token_lifetime():
-    authenticator = VPCInstanceAuthenticator(
-        iam_profile_id=TEST_IAM_PROFILE_ID,
-        url='someurl.com',
-        token_lifetime=600
-    )
+    authenticator = VPCInstanceAuthenticator(iam_profile_id=TEST_IAM_PROFILE_ID, url='someurl.com', token_lifetime=600)
     assert authenticator is not None
     assert authenticator.token_manager.token_lifetime == 600
 
 
 def test_constructor_with_service_version():
     authenticator = VPCInstanceAuthenticator(
-        iam_profile_id=TEST_IAM_PROFILE_ID,
-        url='someurl.com',
-        service_version='2025-08-26'
+        iam_profile_id=TEST_IAM_PROFILE_ID, url='someurl.com', service_version='2025-08-26'
     )
     assert authenticator is not None
     assert authenticator.token_manager.service_version == '2025-08-26'

--- a/test/test_vpc_instance_authenticator.py
+++ b/test/test_vpc_instance_authenticator.py
@@ -51,6 +51,16 @@ def test_constructor_validate_failed():
     assert str(err.value) == 'At most one of "iam_profile_id" or "iam_profile_crn" may be specified.'
 
 
+def test_constructor_with_unsupported_service_version():
+    with pytest.raises(ValueError) as err:
+        VPCInstanceAuthenticator(
+            iam_profile_crn=TEST_IAM_PROFILE_CRN,
+            service_version='2023-12-31',
+        )
+    assert 'Invalid service version' in str(err.value)
+    assert '2022-03-01, 2025-08-26' in str(err.value)
+
+
 def test_authenticate():
     def mock_get_token():
         return 'mock_token'
@@ -102,4 +112,14 @@ def test_set_service_version():
     assert authenticator.token_manager.service_version == '2022-03-01'
 
     authenticator.set_service_version('2025-08-26')
+    assert authenticator.token_manager.service_version == '2025-08-26'
+
+
+def test_get_create_iam_token_path_default_version():
+    authenticator = VPCInstanceAuthenticator(iam_profile_id=TEST_IAM_PROFILE_ID)
+    assert authenticator.token_manager.service_version == '2022-03-01'
+
+
+def test_get_create_iam_token_path_new_version():
+    authenticator = VPCInstanceAuthenticator(iam_profile_id=TEST_IAM_PROFILE_ID, service_version='2025-08-26')
     assert authenticator.token_manager.service_version == '2025-08-26'

--- a/test/test_vpc_instance_token_manager.py
+++ b/test/test_vpc_instance_token_manager.py
@@ -93,6 +93,51 @@ def test_retrieve_instance_identity_token():
 
 
 @responses.activate
+def test_retrieve_instance_identity_token_with_new_service_version():
+    token_manager = VPCInstanceTokenManager(
+        iam_profile_crn=TEST_IAM_PROFILE_CRN,
+        url='http://someurl.com',
+        service_version='2025-08-26',
+    )
+
+    response = {
+        'access_token': TEST_TOKEN,
+    }
+
+    # New service version uses /identity/v1/token instead of /instance_identity/v1/token
+    responses.add(responses.PUT, 'http://someurl.com/identity/v1/token', body=json.dumps(response), status=200)
+
+    ii_token = token_manager.retrieve_instance_identity_token()
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
+    assert responses.calls[0].request.headers['Accept'] == 'application/json'
+    assert responses.calls[0].request.headers['Metadata-Flavor'] == 'ibm'
+    assert responses.calls[0].request.params['version'] == '2025-08-26'
+    assert responses.calls[0].request.body == '{"expires_in": 300}'
+    assert ii_token == TEST_TOKEN
+
+
+@responses.activate
+def test_retrieve_instance_identity_token_with_custom_token_lifetime():
+    token_manager = VPCInstanceTokenManager(
+        iam_profile_crn=TEST_IAM_PROFILE_CRN,
+        url='http://someurl.com',
+        token_lifetime=600,
+    )
+
+    response = {
+        'access_token': TEST_TOKEN,
+    }
+
+    responses.add(responses.PUT, 'http://someurl.com/instance_identity/v1/token', body=json.dumps(response), status=200)
+
+    ii_token = token_manager.retrieve_instance_identity_token()
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.body == '{"expires_in": 600}'
+    assert ii_token == TEST_TOKEN
+
+
+@responses.activate
 def test_retrieve_instance_identity_token_failed():
     token_manager = VPCInstanceTokenManager(
         iam_profile_crn=TEST_IAM_PROFILE_CRN,
@@ -139,6 +184,37 @@ def test_request_token_with_crn():
     assert responses.calls[0].request.headers['User-Agent'].startswith('ibm-python-sdk-core/vpc-instance-authenticator')
     assert responses.calls[0].request.body == '{"trusted_profile": {"crn": "crn:iam-profile:123"}}'
     assert responses.calls[0].request.params['version'] == '2022-03-01'
+
+
+@responses.activate
+def test_request_token_with_new_service_version():
+    token_manager = VPCInstanceTokenManager(
+        iam_profile_crn=TEST_IAM_PROFILE_CRN,
+        service_version='2025-08-26',
+    )
+
+    # Mock the retrieve instance identity token method.
+    def mock_retrieve_instance_identity_token():
+        return TEST_TOKEN
+
+    token_manager.retrieve_instance_identity_token = mock_retrieve_instance_identity_token
+
+    response = {
+        'access_token': TEST_IAM_TOKEN,
+    }
+
+    # New service version uses /identity/v1/iam_tokens instead of /instance_identity/v1/iam_token
+    responses.add(
+        responses.POST, 'http://169.254.169.254/identity/v1/iam_tokens', body=json.dumps(response), status=200
+    )
+
+    response = token_manager.request_token()
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
+    assert responses.calls[0].request.headers['Accept'] == 'application/json'
+    assert responses.calls[0].request.headers['Authorization'] == 'Bearer ' + TEST_TOKEN
+    assert responses.calls[0].request.body == '{"trusted_profile": {"crn": "crn:iam-profile:123"}}'
+    assert responses.calls[0].request.params['version'] == '2025-08-26'
 
 
 @responses.activate

--- a/test/test_vpc_instance_token_manager.py
+++ b/test/test_vpc_instance_token_manager.py
@@ -180,6 +180,7 @@ def test_request_token_with_crn():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
     assert responses.calls[0].request.headers['Accept'] == 'application/json'
+    assert responses.calls[0].request.headers['Metadata-Flavor'] == 'ibm'
     assert responses.calls[0].request.headers['Authorization'] == 'Bearer ' + TEST_TOKEN
     assert responses.calls[0].request.headers['User-Agent'].startswith('ibm-python-sdk-core/vpc-instance-authenticator')
     assert responses.calls[0].request.body == '{"trusted_profile": {"crn": "crn:iam-profile:123"}}'
@@ -212,6 +213,7 @@ def test_request_token_with_new_service_version():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
     assert responses.calls[0].request.headers['Accept'] == 'application/json'
+    assert responses.calls[0].request.headers['Metadata-Flavor'] == 'ibm'
     assert responses.calls[0].request.headers['Authorization'] == 'Bearer ' + TEST_TOKEN
     assert responses.calls[0].request.body == '{"trusted_profile": {"crn": "crn:iam-profile:123"}}'
     assert responses.calls[0].request.params['version'] == '2025-08-26'
@@ -241,6 +243,7 @@ def test_request_token_with_id():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
     assert responses.calls[0].request.headers['Accept'] == 'application/json'
+    assert responses.calls[0].request.headers['Metadata-Flavor'] == 'ibm'
     assert responses.calls[0].request.headers['Authorization'] == 'Bearer ' + TEST_TOKEN
     assert responses.calls[0].request.body == '{"trusted_profile": {"id": "iam-id-123"}}'
     assert responses.calls[0].request.params['version'] == '2022-03-01'
@@ -268,6 +271,7 @@ def test_request_token():
     assert len(responses.calls) == 1
     assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
     assert responses.calls[0].request.headers['Accept'] == 'application/json'
+    assert responses.calls[0].request.headers['Metadata-Flavor'] == 'ibm'
     assert responses.calls[0].request.headers['Authorization'] == 'Bearer ' + TEST_TOKEN
     assert responses.calls[0].request.body is None
     assert responses.calls[0].request.params['version'] == '2022-03-01'
@@ -377,3 +381,35 @@ def test_get_token_success():
     access_token = token_manager.get_token()
     assert access_token == TEST_ACCESS_TOKEN_2
     assert token_manager.access_token == TEST_ACCESS_TOKEN_2
+
+
+@responses.activate
+def test_retrieve_iam_token_with_supported_service_version():
+    """Test retrieving IAM token with new supported service version."""
+    token_manager = VPCInstanceTokenManager(
+        iam_profile_id=TEST_IAM_PROFILE_ID,
+        url='http://someurl.com',
+        service_version='2025-08-26',
+    )
+
+    def mock_retrieve_instance_identity_token():
+        return TEST_TOKEN
+
+    token_manager.retrieve_instance_identity_token = mock_retrieve_instance_identity_token
+
+    response = {
+        'access_token': TEST_IAM_TOKEN,
+    }
+
+    # New service version uses /identity/v1/iam_tokens
+    responses.add(responses.POST, 'http://someurl.com/identity/v1/iam_tokens', body=json.dumps(response), status=200)
+
+    token_response = token_manager.request_token()
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.headers['Content-Type'] == 'application/json'
+    assert responses.calls[0].request.headers['Accept'] == 'application/json'
+    assert responses.calls[0].request.headers['Metadata-Flavor'] == 'ibm'
+    assert responses.calls[0].request.headers['Authorization'] == 'Bearer ' + TEST_TOKEN
+    assert responses.calls[0].request.headers['User-Agent'].startswith('ibm-python-sdk-core/vpc-instance-authenticator')
+    assert responses.calls[0].request.body == '{"trusted_profile": {"id": "iam-id-123"}}'
+    assert token_response['access_token'] == TEST_IAM_TOKEN


### PR DESCRIPTION
This PR adds support for the new VPC Instance Metadata Service version (2025-08-26) with the following changes:

- Added configurable `ServiceVersion` field (default: "2022-03-01") that switches to new API paths (`/identity/v1/token`, `/identity/v1/iam_tokens`) when set to "2025-08-26"
- Added `TokenLifetime` field (default: 300s) for customizable token expiration
- Configuration via builder methods (`SetServiceVersion()`, `SetTokenLifetime()`) or `VPC_IMS_VERSION` environment variable
- **Full backward compatibility with older service versions**